### PR TITLE
Update license for all js/jsx files

### DIFF
--- a/packages/nrfconnect-appmodule-ble/index.js
+++ b/packages/nrfconnect-appmodule-ble/index.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/actions/adapterActions.js
+++ b/packages/nrfconnect-appmodule-ble/js/actions/adapterActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/actions/advertisingActions.js
+++ b/packages/nrfconnect-appmodule-ble/js/actions/advertisingActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/actions/appActions.js
+++ b/packages/nrfconnect-appmodule-ble/js/actions/appActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/actions/bleEventActions.js
+++ b/packages/nrfconnect-appmodule-ble/js/actions/bleEventActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/actions/common.js
+++ b/packages/nrfconnect-appmodule-ble/js/actions/common.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/actions/deviceDetailsActions.js
+++ b/packages/nrfconnect-appmodule-ble/js/actions/deviceDetailsActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/actions/dfuActions.js
+++ b/packages/nrfconnect-appmodule-ble/js/actions/dfuActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/actions/discoveryActions.js
+++ b/packages/nrfconnect-appmodule-ble/js/actions/discoveryActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/actions/errorDialogActions.js
+++ b/packages/nrfconnect-appmodule-ble/js/actions/errorDialogActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/actions/firmwareUpdateActions.js
+++ b/packages/nrfconnect-appmodule-ble/js/actions/firmwareUpdateActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/actions/logActions.js
+++ b/packages/nrfconnect-appmodule-ble/js/actions/logActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/actions/securityActions.js
+++ b/packages/nrfconnect-appmodule-ble/js/actions/securityActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/actions/serverSetupActions.js
+++ b/packages/nrfconnect-appmodule-ble/js/actions/serverSetupActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/common/Errors.js
+++ b/packages/nrfconnect-appmodule-ble/js/common/Errors.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/common/layoutStrategies.js
+++ b/packages/nrfconnect-appmodule-ble/js/common/layoutStrategies.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/common/treeViewKeyNavigation.js
+++ b/packages/nrfconnect-appmodule-ble/js/common/treeViewKeyNavigation.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/AdapterSelector.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/AdapterSelector.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/AddNewItem.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/AddNewItem.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/AdvertisingData.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/AdvertisingData.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/AdvertisingList.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/AdvertisingList.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/AdvertisingListEntry.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/AdvertisingListEntry.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/AttributeItem.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/AttributeItem.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/AuthKeyEditor.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/AuthKeyEditor.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/BLEEvent.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/BLEEvent.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/CentralDevice.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/CentralDevice.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/CharacteristicEditor.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/CharacteristicEditor.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/CharacteristicItem.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/CharacteristicItem.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/ConfirmationDialog.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/ConfirmationDialog.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/ConnectedDevice.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/ConnectedDevice.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/ConnectionUpdateRequestEditor.js
+++ b/packages/nrfconnect-appmodule-ble/js/components/ConnectionUpdateRequestEditor.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/Connector.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/Connector.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/CountdownTimer.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/CountdownTimer.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/DescriptorEditor.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/DescriptorEditor.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/DescriptorItem.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/DescriptorItem.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/DfuButton.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/DfuButton.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/DfuEditor.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/DfuEditor.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/DfuThroughputGraph.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/DfuThroughputGraph.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/DiscoveredDevice.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/DiscoveredDevice.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/EditableField.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/EditableField.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/EnumeratingAttributes.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/EnumeratingAttributes.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/HexOnlyEditableField.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/HexOnlyEditableField.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/LogEntry.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/LogEntry.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/PairingEditor.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/PairingEditor.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/SecurityParamsControls.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/SecurityParamsControls.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/ServiceEditor.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/ServiceEditor.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/ServiceItem.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/ServiceItem.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/UuidLookup.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/UuidLookup.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/__tests__/ConnectedDevice-snapshot-test.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/__tests__/ConnectedDevice-snapshot-test.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/__tests__/ConnectedDevice-test.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/__tests__/ConnectedDevice-test.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/__tests__/DfuEditor-snapshot-test.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/__tests__/DfuEditor-snapshot-test.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/__tests__/DfuEditor-test.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/__tests__/DfuEditor-test.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/__tests__/ServiceItem-snapshot-test.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/__tests__/ServiceItem-snapshot-test.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/__tests__/ServiceItem-test.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/__tests__/ServiceItem-test.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/deviceDetails.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/deviceDetails.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/discoveryButton.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/discoveryButton.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/input/FileInput.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/input/FileInput.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/input/LabeledInputGroup.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/input/LabeledInputGroup.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/input/ProgressBarInput.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/input/ProgressBarInput.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/input/ReadOnlyField.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/input/ReadOnlyField.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/input/SelectList.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/input/SelectList.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/input/TextArea.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/input/TextArea.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/input/TextInput.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/input/TextInput.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/input/UuidInput.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/input/UuidInput.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/components/navbar.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/components/navbar.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/containers/AdvertisingSetup.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/containers/AdvertisingSetup.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/containers/App.js
+++ b/packages/nrfconnect-appmodule-ble/js/containers/App.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/containers/BLEEventDialog.js
+++ b/packages/nrfconnect-appmodule-ble/js/containers/BLEEventDialog.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/containers/DeviceDetails.js
+++ b/packages/nrfconnect-appmodule-ble/js/containers/DeviceDetails.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/containers/DfuDialog.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/containers/DfuDialog.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/containers/DiscoveredDevices.js
+++ b/packages/nrfconnect-appmodule-ble/js/containers/DiscoveredDevices.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/containers/ErrorDialog.js
+++ b/packages/nrfconnect-appmodule-ble/js/containers/ErrorDialog.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/containers/LogViewer.js
+++ b/packages/nrfconnect-appmodule-ble/js/containers/LogViewer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/containers/Root.dev.js
+++ b/packages/nrfconnect-appmodule-ble/js/containers/Root.dev.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/containers/Root.js
+++ b/packages/nrfconnect-appmodule-ble/js/containers/Root.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/containers/Root.prod.js
+++ b/packages/nrfconnect-appmodule-ble/js/containers/Root.prod.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/containers/SecurityParamsDialog.js
+++ b/packages/nrfconnect-appmodule-ble/js/containers/SecurityParamsDialog.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/containers/ServerSetup.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/containers/ServerSetup.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/gattDatabases.js
+++ b/packages/nrfconnect-appmodule-ble/js/gattDatabases.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/index.js
+++ b/packages/nrfconnect-appmodule-ble/js/index.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/logging/index.js
+++ b/packages/nrfconnect-appmodule-ble/js/logging/index.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/logging/logger.js
+++ b/packages/nrfconnect-appmodule-ble/js/logging/logger.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/reducers/__tests__/dfuReducer-test.js
+++ b/packages/nrfconnect-appmodule-ble/js/reducers/__tests__/dfuReducer-test.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/reducers/adapterReducer.js
+++ b/packages/nrfconnect-appmodule-ble/js/reducers/adapterReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/reducers/advertisingReducer.js
+++ b/packages/nrfconnect-appmodule-ble/js/reducers/advertisingReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/reducers/appReducer.js
+++ b/packages/nrfconnect-appmodule-ble/js/reducers/appReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/reducers/bleEventReducer.js
+++ b/packages/nrfconnect-appmodule-ble/js/reducers/bleEventReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/reducers/deviceDetailsReducer.js
+++ b/packages/nrfconnect-appmodule-ble/js/reducers/deviceDetailsReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/reducers/dfuReducer.js
+++ b/packages/nrfconnect-appmodule-ble/js/reducers/dfuReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/reducers/discoveryReducer.js
+++ b/packages/nrfconnect-appmodule-ble/js/reducers/discoveryReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/reducers/errorDialogReducer.js
+++ b/packages/nrfconnect-appmodule-ble/js/reducers/errorDialogReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/reducers/firmwareUpdateReducer.js
+++ b/packages/nrfconnect-appmodule-ble/js/reducers/firmwareUpdateReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/reducers/index.js
+++ b/packages/nrfconnect-appmodule-ble/js/reducers/index.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/reducers/logReducer.js
+++ b/packages/nrfconnect-appmodule-ble/js/reducers/logReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/reducers/securityReducer.js
+++ b/packages/nrfconnect-appmodule-ble/js/reducers/securityReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/reducers/serverSetupReducer.js
+++ b/packages/nrfconnect-appmodule-ble/js/reducers/serverSetupReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/utils/Effects.jsx
+++ b/packages/nrfconnect-appmodule-ble/js/utils/Effects.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/utils/api.js
+++ b/packages/nrfconnect-appmodule-ble/js/utils/api.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/utils/colorDefinitions.js
+++ b/packages/nrfconnect-appmodule-ble/js/utils/colorDefinitions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/utils/definitions.js
+++ b/packages/nrfconnect-appmodule-ble/js/utils/definitions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/utils/dummyAttributeData.js
+++ b/packages/nrfconnect-appmodule-ble/js/utils/dummyAttributeData.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/utils/fileUtil.js
+++ b/packages/nrfconnect-appmodule-ble/js/utils/fileUtil.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/utils/jlinkUtil.js
+++ b/packages/nrfconnect-appmodule-ble/js/utils/jlinkUtil.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/utils/stringUtil.js
+++ b/packages/nrfconnect-appmodule-ble/js/utils/stringUtil.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/utils/uuid_definitions.js
+++ b/packages/nrfconnect-appmodule-ble/js/utils/uuid_definitions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-ble/js/utils/validateUuid.js
+++ b/packages/nrfconnect-appmodule-ble/js/utils/validateUuid.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-sample/index.js
+++ b/packages/nrfconnect-appmodule-sample/index.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-sample/js/actions/appActions.js
+++ b/packages/nrfconnect-appmodule-sample/js/actions/appActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-sample/js/components/SimpleCounter.jsx
+++ b/packages/nrfconnect-appmodule-sample/js/components/SimpleCounter.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-sample/js/components/__tests__/SimpleCounter-test.jsx
+++ b/packages/nrfconnect-appmodule-sample/js/components/__tests__/SimpleCounter-test.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-sample/js/containers/App.jsx
+++ b/packages/nrfconnect-appmodule-sample/js/containers/App.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-sample/js/containers/Root.jsx
+++ b/packages/nrfconnect-appmodule-sample/js/containers/Root.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-sample/js/index.js
+++ b/packages/nrfconnect-appmodule-sample/js/index.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-sample/js/reducers/appReducer.js
+++ b/packages/nrfconnect-appmodule-sample/js/reducers/appReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-appmodule-sample/js/reducers/index.js
+++ b/packages/nrfconnect-appmodule-sample/js/reducers/index.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/index.js
+++ b/packages/nrfconnect-core/index.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/js/actions/errorDialogActions.js
+++ b/packages/nrfconnect-core/js/actions/errorDialogActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/js/components/Spinner.jsx
+++ b/packages/nrfconnect-core/js/components/Spinner.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/js/components/input/LabeledInputGroup.jsx
+++ b/packages/nrfconnect-core/js/components/input/LabeledInputGroup.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/js/components/input/SelectList.jsx
+++ b/packages/nrfconnect-core/js/components/input/SelectList.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/js/components/input/TextArea.jsx
+++ b/packages/nrfconnect-core/js/components/input/TextArea.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/js/components/input/TextInput.jsx
+++ b/packages/nrfconnect-core/js/components/input/TextInput.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/js/containers/DevTools.dev.js
+++ b/packages/nrfconnect-core/js/containers/DevTools.dev.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/js/containers/DevTools.js
+++ b/packages/nrfconnect-core/js/containers/DevTools.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/js/containers/DevTools.prod.js
+++ b/packages/nrfconnect-core/js/containers/DevTools.prod.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/js/containers/ErrorDialog.js
+++ b/packages/nrfconnect-core/js/containers/ErrorDialog.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/js/index.js
+++ b/packages/nrfconnect-core/js/index.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/js/loader.js
+++ b/packages/nrfconnect-core/js/loader.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/js/reducers/errorDialogReducer.js
+++ b/packages/nrfconnect-core/js/reducers/errorDialogReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/js/store/configureStore.js
+++ b/packages/nrfconnect-core/js/store/configureStore.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-core/settings.js
+++ b/packages/nrfconnect-core/settings.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-loader/index.js
+++ b/packages/nrfconnect-loader/index.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-loader/js/actions/appActions.js
+++ b/packages/nrfconnect-loader/js/actions/appActions.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-loader/js/components/AppmoduleList.jsx
+++ b/packages/nrfconnect-loader/js/components/AppmoduleList.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-loader/js/components/AppmoduleListItem.jsx
+++ b/packages/nrfconnect-loader/js/components/AppmoduleListItem.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-loader/js/components/AppmoduleLoader.jsx
+++ b/packages/nrfconnect-loader/js/components/AppmoduleLoader.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-loader/js/components/__tests__/AppmoduleList-test.jsx
+++ b/packages/nrfconnect-loader/js/components/__tests__/AppmoduleList-test.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-loader/js/components/__tests__/AppmoduleLoader-test.jsx
+++ b/packages/nrfconnect-loader/js/components/__tests__/AppmoduleLoader-test.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-loader/js/containers/App.jsx
+++ b/packages/nrfconnect-loader/js/containers/App.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-loader/js/containers/Root.jsx
+++ b/packages/nrfconnect-loader/js/containers/Root.jsx
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-loader/js/index.js
+++ b/packages/nrfconnect-loader/js/index.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-loader/js/reducers/appReducer.js
+++ b/packages/nrfconnect-loader/js/reducers/appReducer.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-loader/js/reducers/index.js
+++ b/packages/nrfconnect-loader/js/reducers/index.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-loader/js/utils/api.js
+++ b/packages/nrfconnect-loader/js/utils/api.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/packages/nrfconnect-loader/js/utils/appmoduleRepository.js
+++ b/packages/nrfconnect-loader/js/utils/appmoduleRepository.js
@@ -1,4 +1,5 @@
-/* Copyright (c) 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -22,6 +23,7 @@
  *
  *   5. Any software provided in binary form under this license must not be
  *   reverse engineered, decompiled, modified and/or disassembled.
+ *
  *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF


### PR DESCRIPTION
Updated to the latest Nordic 5-Clause License for all js/jsx files in the repository.

Note: The original license document had "Copyright (c) 2016". Have updated this to "Copyright (c) 2017". Verify if this is ok before merging.

Edit: Got feedback that we should still use 2016, so I have switched back to that. This PR is ready for review/merge now.