### PR TITLE
Fix issue at startup when settings.json is invalid

### DIFF
--- a/packages/nrfconnect-core/settings.js
+++ b/packages/nrfconnect-core/settings.js
@@ -39,12 +39,13 @@
 
 'use strict';
 
-var app = require('electron').app;
-var fs = require('fs');
-var path = require('path');
-var data = null;
+const app = require('electron').app;
+const fs = require('fs');
+const path = require('path');
 
-var filePath = path.join(app.getPath('userData'), 'settings.json');
+let data = null;
+
+const filePath = path.join(app.getPath('userData'), 'settings.json');
 
 function parseSettingsFile() {
     if (!fs.existsSync(filePath)) {
@@ -74,15 +75,15 @@ function save() {
     fs.writeFileSync(filePath, JSON.stringify(data));
 }
 
-exports.set = function (key, value) {
+exports.set = (key, value) => {
     load();
     data[key] = value;
     save();
 };
 
-exports.get = function (key) {
+exports.get = key => {
     load();
-    var value = null;
+    let value = null;
 
     if (key in data) {
         value = data[key];
@@ -91,7 +92,7 @@ exports.get = function (key) {
     return value;
 };
 
-exports.unset = function (key) {
+exports.unset = key => {
     load();
     if (key in data) {
         delete data[key];
@@ -99,8 +100,8 @@ exports.unset = function (key) {
     }
 };
 
-exports.loadLastWindow = function () {
-    var lastWindowState = this.get('lastWindowState');
+exports.loadLastWindow = () => {
+    let lastWindowState = this.get('lastWindowState');
 
     if (lastWindowState === null) {
         lastWindowState = {
@@ -113,8 +114,8 @@ exports.loadLastWindow = function () {
     return lastWindowState;
 };
 
-exports.storeLastWindow = function (lastWindowState) {
-    var bounds = lastWindowState.getBounds();
+exports.storeLastWindow = lastWindowState => {
+    const bounds = lastWindowState.getBounds();
 
     this.set('lastWindowState', {
         x: bounds.x,


### PR DESCRIPTION
In settings.js we currently assume that the contents of settings.json is always an object. We cannot always assume this, f.ex. if the user edits settings.json manually or the application somehow corrupts the file. If settings.json is invalid, it may cause a crash at startup. See this bug report for more info: http://projecttools.nordicsemi.no/jira/browse/NCP-911.

Improving the load routine in settings.js, so that it checks if the settings data from the file is null or not an object. If that is the case, a new empty settings object is created.