### PR TITLE
Use hex string instead of path when programming

### DIFF
--- a/lib/actions/firmwareActions.js
+++ b/lib/actions/firmwareActions.js
@@ -82,11 +82,11 @@ export function validateFirmware(serialNumber, { onValid, onInvalid }) {
 export function programFirmware(serialNumber, { onSuccess, onFailure }) {
     return () => {
         const files = {
-            nrf51: bleDriver.getFirmwarePath('nrf51'),
-            nrf52: bleDriver.getFirmwarePath('nrf52'),
+            nrf51: bleDriver.getFirmwareString('nrf51'),
+            nrf52: bleDriver.getFirmwareString('nrf52'),
             isRelativeToApp: false,
         };
-        programming.programWithHexFile(serialNumber, files)
+        programming.programWithHexString(serialNumber, files)
         .then(() => {
             checkVersionInfo(serialNumber, {
                 onValid: onSuccess,


### PR DESCRIPTION
When nRF Connect is contained in an asar archive, the connectivity hex file is inside the asar. Then nrfjprog will not be able to read the file. Using `getFirmwareString` and `programWithHexString` instead, so that we avoid involving the file system.