### PR TITLE
Fix timeout errors when opening adapter

### DIFF
--- a/lib/actions/adapterActions.js
+++ b/lib/actions/adapterActions.js
@@ -1072,16 +1072,36 @@ export function findAdapters() {
     );
 }
 
+function closeSelectedAdapter(dispatch, getState) {
+    return new Promise((resolve, reject) => {
+        const adapter = getState().app.adapter.api.selectedAdapter;
+        if (adapter) {
+            adapter.close(error => {
+                if (error) {
+                    reject(new Error(error.message));
+                } else {
+                    resolve(adapter);
+                }
+            });
+        }
+    }).then(adapter => {
+        dispatch(adapterClosedAction(adapter));
+    }).catch(error => {
+        dispatch(showErrorDialog(error));
+    });
+}
+
 export function openAdapter(port, versionInfo) {
     return (dispatch, getState) => (
         new Promise((resolve, reject) => {
             // Check if we already have an adapter open, if so, close it
             if (getState().app.adapter.api.selectedAdapter !== null) {
-                dispatch(closeAdapter()).then(() => {
-                    resolve();
-                }).catch(error => {
-                    reject(error);
-                });
+                closeSelectedAdapter(dispatch, getState)
+                    .then(() => {
+                        resolve();
+                    }).catch(error => {
+                        reject(error);
+                    });
             } else {
                 resolve();
             }
@@ -1126,22 +1146,7 @@ export function openAdapter(port, versionInfo) {
 
 export function closeAdapter() {
     return (dispatch, getState) => (
-        new Promise((resolve, reject) => {
-            const adapter = getState().app.adapter.api.selectedAdapter;
-            if (adapter) {
-                adapter.close(error => {
-                    if (error) {
-                        reject(new Error(error.message));
-                    } else {
-                        resolve(adapter);
-                    }
-                });
-            }
-        }).then(adapter => {
-            dispatch(adapterClosedAction(adapter));
-        }).catch(error => {
-            dispatch(showErrorDialog(error));
-        })
+        closeSelectedAdapter(dispatch, getState)
     );
 }
 

--- a/lib/actions/adapterActions.js
+++ b/lib/actions/adapterActions.js
@@ -1126,13 +1126,18 @@ export function openAdapter(port, versionInfo) {
                 dispatch(adapterOpenAction(adapterToUse));
                 setupListeners(dispatch, getState, adapterToUse);
 
-                adapterToUse.open(options, error => {
-                    if (error) {
-                        reject(error); // Let the error event inform the user about the error.
-                        return;
-                    }
-                    resolve(adapterToUse);
-                });
+                // Opening adapter fails occasionally when trying to open right after validatePort
+                // has done the SerialPort.open/close procedure. Applying this setTimeout hack, so
+                // that the port/devkit has some time to clean up before we open.
+                setTimeout(() => {
+                    adapterToUse.open(options, error => {
+                        if (error) {
+                            reject(error); // Let the error event inform the user about the error.
+                            return;
+                        }
+                        resolve(adapterToUse);
+                    });
+                }, 500);
             }).then(adapter => {
                 dispatch(adapterOpenedAction(adapter));
             })


### PR DESCRIPTION
When opening adapter, it occasionally fails with a timeout error. If an adapter is already open, it should close that before opening. Here there was a bug, where it continued to open the adapter before the old one had been properly closed.

Also the SerialPort.open/close procedure that happens right before opening seems to cause problems for pc-ble-driver-js. There are occasional timeout errors when opening adapter. Adding a short delay before opening, so that the port/devkit has some time to clean up.