### PR TITLE
Fix issue with custom UUIDs interfering with normal behavior

### DIFF
--- a/lib/actions/deviceDetailsActions.js
+++ b/lib/actions/deviceDetailsActions.js
@@ -43,7 +43,8 @@ import { logger } from 'nrfconnect/core';
 import { getInstanceIds } from '../utils/api';
 import openFileInDefaultApplication from '../utils/fileUtil';
 import { showErrorDialog } from './errorDialogActions';
-import { getUuidByName, getUuidDefinitionsFilePath } from '../utils/uuid_definitions';
+import { getUuidDefinitionsFilePath } from '../utils/uuid_definitions';
+import { GENERIC_ACCESS_UUID, DEVICE_NAME_UUID } from '../utils/definitions';
 
 export const SELECT_COMPONENT = 'DEVICE_DETAILS_SELECT_COMPONENT';
 
@@ -65,8 +66,7 @@ export const ERROR_OCCURED = 'DEVICE_DETAILS_ERROR_OCCURED';
 
 function discoverNameOfDevice(dispatch, getState, device, services) {
     return new Promise((resolve, reject) => {
-        const genericAccessUuid = getUuidByName('Generic Access');
-        const gapService = services.find(service => service.uuid === genericAccessUuid);
+        const gapService = services.find(service => service.uuid === GENERIC_ACCESS_UUID);
         if (gapService) {
             resolve(gapService);
             return;
@@ -74,9 +74,8 @@ function discoverNameOfDevice(dispatch, getState, device, services) {
         reject(new Error('Could not find GAP service'));
     }).then(gapService => dispatch(discoverCharacteristicsAndDescriptors(gapService)))
     .then(characteristics => {
-        const deviceNameUuid = getUuidByName('Device Name');
         const deviceNameCharacteristic =
-            characteristics.find(characteristic => (characteristic.uuid === deviceNameUuid));
+            characteristics.find(characteristic => (characteristic.uuid === DEVICE_NAME_UUID));
         if (deviceNameCharacteristic) {
             return dispatch(readCharacteristic(deviceNameCharacteristic));
         }

--- a/lib/components/ConnectedDevice.jsx
+++ b/lib/components/ConnectedDevice.jsx
@@ -138,7 +138,7 @@ class ConnectedDevice extends React.PureComponent {
 
         return (
             <div
-                ref={node => (this.node = node)}
+                ref={node => { this.node = node; }}
                 id={id}
                 className="device standalone"
                 style={style}

--- a/lib/components/deviceDetails.jsx
+++ b/lib/components/deviceDetails.jsx
@@ -45,12 +45,11 @@ import ConnectedDevice from './ConnectedDevice';
 import CentralDevice from './CentralDevice';
 import EnumeratingAttributes from './EnumeratingAttributes';
 import ServiceItem from './ServiceItem';
-import { getUuidByName } from '../utils/uuid_definitions';
+import { SECURE_DFU_UUID } from '../utils/definitions';
 
 class DeviceDetailsView extends React.PureComponent {
     constructor(props) {
         super(props);
-        this.dfuUuid = getUuidByName('Secure DFU');
 
         this.onDisconnectFromDevice = this.onDisconnectFromDevice.bind(this);
         this.onUpdateDeviceConnectionParams = this.onUpdateDeviceConnectionParams.bind(this);
@@ -110,7 +109,7 @@ class DeviceDetailsView extends React.PureComponent {
         if (!deviceDetail.discoveringChildren) {
             const services = deviceDetail.get('children');
             if (services) {
-                return services.some(service => service.uuid === this.dfuUuid);
+                return services.some(service => service.uuid === SECURE_DFU_UUID);
             }
         }
         return false;

--- a/lib/reducers/adapterReducer.js
+++ b/lib/reducers/adapterReducer.js
@@ -305,17 +305,13 @@ function addBondInfo(state, device) {
     return state.setIn(['adapters', index, 'connectedDevices', device.instanceId, 'bonded'], true);
 }
 
-function deleteBondInfo(oldState) {
-    let state = oldState;
+function deleteBondInfo(state) {
     const { index } = getSelectedAdapter(state);
-
     const devices = state.getIn(['adapters', index, 'connectedDevices']);
 
-    devices.map(device => (
-        state = state.setIn(['adapters', index, 'connectedDevices', device.instanceId, 'bonded'], false)
-    ));
-
-    return state;
+    return devices.reduce((prevState, device) => (
+        prevState.setIn(['adapters', index, 'connectedDevices', device.instanceId, 'bonded'], false)
+    ), state);
 }
 
 function serverSetupApplied(state) {

--- a/lib/utils/definitions.js
+++ b/lib/utils/definitions.js
@@ -44,6 +44,10 @@
 export const TEXT = 'TEXT';
 export const NO_FORMAT = 'NO_FORMAT';
 
+export const GENERIC_ACCESS_UUID = '1800';
+export const DEVICE_NAME_UUID = '2A00';
+export const SECURE_DFU_UUID = 'FE59';
+
 /* eslint quote-props: ["error", "as-needed", { "numbers": true, "unnecessary": false }] */
 
 export const uuid16bitGattDefinitions = {
@@ -54,7 +58,7 @@ export const uuid16bitGattDefinitions = {
 };
 
 export const uuid16bitServiceDefinitions = {
-    '1800': { name: 'Generic Access' },
+    [GENERIC_ACCESS_UUID]: { name: 'Generic Access' },
     '1801': { name: 'Generic Attribute' },
     '1802': { name: 'Immediate Alert' },
     '1803': { name: 'Link Loss' },
@@ -86,11 +90,11 @@ export const uuid16bitServiceDefinitions = {
     '1820': { name: 'Internet Protocol Support' },
     '1821': { name: 'Indoor Positioning' },
     '1822': { name: 'Pulse Oximeter' },
-    'FE59': { name: 'Secure DFU' },
+    [SECURE_DFU_UUID]: { name: 'Secure DFU' },
 };
 
 export const uuid16bitCharacteristicDefinitions = {
-    '2A00': { name: 'Device Name', format: TEXT },
+    [DEVICE_NAME_UUID]: { name: 'Device Name', format: TEXT },
     '2A01': { name: 'Appearance' },
     '2A02': { name: 'Peripheral Privacy Flag' },
     '2A03': { name: 'Reconnection Address' },

--- a/lib/utils/uuid_definitions.js
+++ b/lib/utils/uuid_definitions.js
@@ -198,20 +198,6 @@ export function getUuidName(uuid) {
     return uuid;
 }
 
-export function getUuidByName(name) {
-    const uuidDefs = uuidDefinitions();
-    const keys = Object.keys(uuidDefs);
-    for (let i = 0; i < keys.length; i += 1) {
-        const uuid = keys[i];
-        if (Object.prototype.hasOwnProperty.call(uuidDefs, uuid)) {
-            if (uuidDefs[uuid].name === name) {
-                return uuid;
-            }
-        }
-    }
-    return undefined;
-}
-
 export function getPrettyUuid(uuid) {
     if (uuid.length === 4) {
         return uuid.toUpperCase();


### PR DESCRIPTION
We now refer to UUID constants instead of looking up the UUIDs by name. The lookup by name did also search among custom UUIDs, which was problematic. The user could have specified e.g. a custom Device Name or Secure DFU UUID, which would cause the device name to not appear, or the DFU button to not be displayed.