### PR TITLE
Use correct Bluetooth Low Energy name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# nRF Connect Bluetooth<sup>&reg;</sup> low energy
+# nRF Connect Bluetooth Low Energy
 
 [![Build Status](https://travis-ci.org/NordicSemiconductor/pc-nrfconnect-ble.svg?branch=master)](https://travis-ci.org/NordicSemiconductor/pc-nrfconnect-ble) [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
-*nRF Connect Bluetooth<sup>&reg;</sup> low energy* is a cross-platform tool that enables testing and development with Bluetooth<sup>&reg;</sup> low energy (previously called Bluetooth Smart). It allows easy setup of connections with other devices and use these connections for reading and writing to the external nodes.
+*nRF Connect Bluetooth<sup>&reg;</sup> Low Energy* is a cross-platform tool that enables testing and development with Bluetooth Low Energy (previously called Bluetooth Smart). It allows easy setup of connections with other devices and use these connections for reading and writing to the external nodes.
 
-*nRF Connect Bluetooth<sup>&reg;</sup> low energy* is implemented as an app for [nRF Connect](https://github.com/NordicSemiconductor/pc-nrfconnect-core#creating-apps).
+*nRF Connect Bluetooth Low Energy* is implemented as an app for [nRF Connect](https://github.com/NordicSemiconductor/pc-nrfconnect-core#creating-apps).
 
 ![screenshot](resources/ble-screenshot.png)
 
@@ -20,11 +20,11 @@ nRF Connect currently supports the following operating systems:
 * Ubuntu Linux 64-bit
 * macOS
 
-After *nRF Connect* is installed, you can find *Bluetooth<sup>&reg;</sup> low energy* in the app list by selecting *Add/remove apps*.
+After *nRF Connect* is installed, you can find *Bluetooth Low Energy* in the app list by selecting *Add/remove apps*.
 
 # Usage documentation
 
-A [User guide](http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.tools/dita/tools/nRF_Connect/nRF_Connect_intro.html?cp=4_2) is available on the *nRF Connect Bluetooth<sup>&reg;</sup> low energy* product pages.
+A [User guide](http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.tools/dita/tools/nRF_Connect/nRF_Connect_intro.html?cp=4_2) is available on the *nRF Connect Bluetooth Low Energy* product pages.
 
 # Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "pc-nrfconnect-ble",
   "version": "2.0.1",
-  "description": "A natural first choice for Bluetooth low energy development",
-  "displayName": "Bluetooth low energy",
+  "description": "A natural first choice for Bluetooth Low Energy development",
+  "displayName": "Bluetooth Low Energy",
   "repository": {
     "type": "git",
     "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-ble.git"


### PR DESCRIPTION
Updating the name according to latest policy:
- Uppercase all words in Bluetooth Low Energy.
- Use Bluetooth® only for the first occurrence in the body text.