### PR TITLE
Fix cryptic error when unplugging device

### DIFF
--- a/lib/reducers/adapterReducer.js
+++ b/lib/reducers/adapterReducer.js
@@ -143,8 +143,14 @@ function closeAdapter(oldState, adapter) {
     state.api.selectedAdapter = null;
 
     const index = state.api.adapters.indexOf(adapter);
-    state = state.setIn(['adapters', index, 'isServerSetupApplied'], false);
-    state = state.updateIn(['adapters', index, 'connectedDevices'], connectedDevices => connectedDevices.clear());
+    const adapterExists = index !== -1;
+
+    // The adapter may have been unplugged before close is called, and then
+    // it will no longer exist in the adapters list
+    if (adapterExists) {
+        state = state.setIn(['adapters', index, 'isServerSetupApplied'], false);
+        state = state.updateIn(['adapters', index, 'connectedDevices'], connectedDevices => connectedDevices.clear());
+    }
 
     state = state.set('adapterIndicator', 'off');
     state = state.set('selectedAdapterIndex', null);


### PR DESCRIPTION
When a devkit/dongle was unplugged while being open, an error would pop up saying: "Error when calling 'reduceApp': Cannot read property 'clear' of undefined".

This happened because the reducer tried to update the state for an already removed adapter. Now checking if the adapter exists before updating state.