### PR TITLE
Make errors from AdapterFactory less intrusive

### DIFF
--- a/lib/actions/adapterActions.js
+++ b/lib/actions/adapterActions.js
@@ -1059,6 +1059,7 @@ export function findAdapters() {
             adapterFactory.on('error', error => {
                 logger.error(`Error when processing adapters: ${error.message}`);
             });
+            adapterFactory.on('logMessage', onLogMessage);
 
             adapterFactory.getAdapters(error => {
                 if (error) {

--- a/lib/actions/adapterActions.js
+++ b/lib/actions/adapterActions.js
@@ -1057,7 +1057,7 @@ export function findAdapters() {
                 dispatch(adapterRemovedAction(adapter));
             });
             adapterFactory.on('error', error => {
-                dispatch(showErrorDialog(new Error(error.message)));
+                logger.error(`Error when processing adapters: ${error.message}`);
             });
 
             adapterFactory.getAdapters(error => {


### PR DESCRIPTION
The AdapterFactory checks for new adapters every 2 seconds. If something fails in this routine, the same error may be emitted multiple times. Showing an error dialog in these cases will make the completely app unusable, so logging the error instead. It will show up in the log viewer and in the log file.