### PR TITLE
Change BLE driver event interval from 10 ms to 0

### DIFF
--- a/lib/actions/adapterActions.js
+++ b/lib/actions/adapterActions.js
@@ -1168,7 +1168,7 @@ export function openAdapter(port, versionInfo) {
                     baudRate,
                     parity: 'none',
                     flowControl: 'none',
-                    eventInterval: 10,
+                    eventInterval: 0,
                     logLevel: 'debug',
                     enableBLE: false,
                 };


### PR DESCRIPTION
When opening an adapter with pc-ble-driver-js, it is possible to specify an `eventInterval` option, which is how often BLE events should be sent up from pc-ble-driver to pc-ble-driver-js. This has been set to 10 ms to avoid flooding the UI with events, which could make it unresponsive.

However, many changes has been made to nRF Connect since the event interval mechanism was introduced, and recent tests indicate that `eventInterval: 0` (which disables the event inverval) does not cause problems for the UI.

The main motivation for disabling the event interval is to avoid slowing down the DFU. The DFU procedure waits for events when performing write operations, so we want these events to arrive as fast as possible.