### PR TITLE
Fix issue with server setup not opening

### DIFF
--- a/lib/containers/ServerSetup.jsx
+++ b/lib/containers/ServerSetup.jsx
@@ -254,6 +254,7 @@ class ServerSetup extends React.PureComponent {
     render() {
         const {
             selectedAdapter,
+            deviceInfo,
             serverSetup,
             // selectComponent,
             setAttributeExpanded,
@@ -373,6 +374,7 @@ class ServerSetup extends React.PureComponent {
                 id={`${selectedAdapter.instanceId}_serversetup`}
                 name={selectedAdapter.state.name}
                 address={selectedAdapter.state.address}
+                deviceInfo={deviceInfo}
                 onSaveSetup={this.openSaveDialog}
                 onLoadSetup={this.openLoadDialog}
             />
@@ -449,7 +451,11 @@ class ServerSetup extends React.PureComponent {
 }
 
 function mapStateToProps(state) {
-    const selectedAdapter = state.app.adapter.getIn(['adapters', state.app.adapter.selectedAdapterIndex]);
+    const {
+        adapter,
+    } = state.app;
+
+    const selectedAdapter = adapter.getIn(['adapters', adapter.selectedAdapterIndex]);
 
     if (!selectedAdapter) {
         return {};
@@ -457,6 +463,7 @@ function mapStateToProps(state) {
 
     return {
         selectedAdapter,
+        deviceInfo: adapter.deviceInfo,
         serverSetup: selectedAdapter.serverSetup,
     };
 }
@@ -479,6 +486,7 @@ export default connect(
 
 ServerSetup.propTypes = {
     selectedAdapter: PropTypes.instanceOf(ImmutableAdapter),
+    deviceInfo: PropTypes.object,
     serverSetup: PropTypes.object,
     saveServerSetup: PropTypes.func.isRequired,
     loadServerSetup: PropTypes.func.isRequired,
@@ -508,4 +516,5 @@ ServerSetup.propTypes = {
 ServerSetup.defaultProps = {
     selectedAdapter: null,
     serverSetup: null,
+    deviceInfo: null,
 };


### PR DESCRIPTION
In #72, a `deviceInfo` property was added to `CentralDevice`. This component is used by both `DeviceDetails` and `ServerSetup`, but the device info was only specified by `DeviceDetails`. Adding it to `ServerSetup` as well.