### PR TITLE
Log J-Link firmware string when selecting serial port

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -38,7 +38,7 @@ import path from 'path';
 import React from 'react';
 import { bindActionCreators } from 'redux';
 import { getAppDir, getUserDataDir, logger } from 'nrfconnect/core';
-import { getFirmwareInfo, programConnectivityFirmware } from './lib/api/firmware';
+import { getFirmwareInfo, programConnectivityFirmware } from './lib/api/nrfjprog';
 import reducers from './lib/reducers';
 import * as DiscoveryActions from './lib/actions/discoveryActions';
 import * as AdapterActions from './lib/actions/adapterActions';

--- a/lib/actions/adapterActions.js
+++ b/lib/actions/adapterActions.js
@@ -60,7 +60,7 @@ export const ADAPTER_STATE_CHANGED = 'ADAPTER_STATE_CHANGED';
 export const ADAPTER_RESET_PERFORMED = 'ADAPTER_RESET_PERFORMED';
 export const ADAPTER_SCAN_TIMEOUT = 'ADAPTER_SCAN_TIMEOUT';
 export const ADAPTER_ADVERTISEMENT_TIMEOUT = 'ADAPTER_ADVERTISEMENT_TIMEOUT';
-export const ADAPTER_GET_LOCAL_DEVICE_INFO = 'ADAPTER_GET_LOCAL_DEVICE_INFO';
+export const ADAPTER_LOCAL_DEVICE_INFO_LOADED = 'ADAPTER_LOCAL_DEVICE_INFO_LOADED';
 
 export const DEVICE_DISCOVERED = 'DEVICE_DISCOVERED';
 export const DEVICE_CONNECT = 'DEVICE_CONNECT';
@@ -125,13 +125,6 @@ const secKeyset = {
 };
 
 let throttledValueChangedDispatch;
-
-function adapterGetLocalDeviceInfoAction(deviceInfo) {
-    return {
-        type: ADAPTER_GET_LOCAL_DEVICE_INFO,
-        deviceInfo,
-    };
-}
 
 function adapterOpenedAction(adapter, versionInfo) {
     return {
@@ -252,6 +245,13 @@ function advertiseTimeoutAction(adapter) {
     return {
         type: ADAPTER_ADVERTISEMENT_TIMEOUT,
         adapter,
+    };
+}
+
+function adapterLocalDeviceInfoLoadedAction(deviceInfo) {
+    return {
+        type: ADAPTER_LOCAL_DEVICE_INFO_LOADED,
+        deviceInfo,
     };
 }
 
@@ -1113,7 +1113,7 @@ export function selectedSerialPort(port) {
             getAllDeviceInfo(port.serialNumber)
                 .then(allDeviceInfo => {
                     const { deviceInfo, firmwareInfo, probeInfo } = allDeviceInfo;
-                    dispatch(adapterGetLocalDeviceInfoAction(deviceInfo));
+                    dispatch(adapterLocalDeviceInfoLoadedAction(deviceInfo));
                     logger.info(`Device type: ${deviceTypeDefinitions[deviceInfo.deviceType]}. ` +
                         `J-Link serial number: ${probeInfo.serialNumber}. ` +
                         `J-Link firmware: ${probeInfo.firmwareString}.`);

--- a/lib/actions/adapterActions.js
+++ b/lib/actions/adapterActions.js
@@ -46,7 +46,7 @@ import SerialPort from 'serialport';
 import { discoverServices } from './deviceDetailsActions';
 import { BLEEventState } from './common';
 import { showErrorDialog } from './errorDialogActions';
-import { getDeviceAndFirmwareInfo } from './../api/firmware';
+import { getAllDeviceInfo } from './../api/nrfjprog';
 import { hexStringToArray, toHexString } from '../utils/stringUtil';
 import { deviceTypeDefinitions } from '../utils/deviceDefinitions';
 
@@ -1110,11 +1110,14 @@ function closeSelectedAdapter(dispatch, getState) {
 export function selectedSerialPort(port) {
     return dispatch => (
         dispatch(closeAdapter(() => {
-            getDeviceAndFirmwareInfo(port.serialNumber)
-                .then(deviceAndFirmwareInfo => {
-                    const { deviceInfo, firmwareInfo } = deviceAndFirmwareInfo;
+            getAllDeviceInfo(port.serialNumber)
+                .then(allDeviceInfo => {
+                    const { deviceInfo, firmwareInfo, probeInfo } = allDeviceInfo;
                     dispatch(adapterGetLocalDeviceInfoAction(deviceInfo));
-                    logger.info(`Current device type is ${deviceTypeDefinitions[deviceInfo.deviceType]}`);
+                    logger.info(`Device type: ${deviceTypeDefinitions[deviceInfo.deviceType]}. ` +
+                        `J-Link serial number: ${probeInfo.serialNumber}. ` +
+                        `J-Link firmware: ${probeInfo.firmwareString}.`);
+
                     if (firmwareInfo.isUpdateRequired) {
                         dispatch({ type: 'FIRMWARE_DIALOG_SHOW', port });
                     } else {
@@ -1148,10 +1151,9 @@ export function openAdapter(port, versionInfo) {
                     return;
                 }
 
-                logger.info(`Connectivity firmware version: ${versionInfo.version}, ` +
-                    `sdBleApiVersion: ${versionInfo.sdBleApiVersion}, ` +
-                    `baudRate: ${versionInfo.baudRate}, ` +
-                    `transportType: ${versionInfo.transportType}`);
+                logger.info(`Connectivity firmware version: ${versionInfo.version}. ` +
+                    `SoftDevice version: ${versionInfo.sdBleApiVersion}. ` +
+                    `Baud rate: ${versionInfo.baudRate}.`);
 
                 const { baudRate } = versionInfo;
                 const options = {

--- a/lib/api/nrfjprog.js
+++ b/lib/api/nrfjprog.js
@@ -75,7 +75,19 @@ function getDeviceInfo(serialNumber) {
     });
 }
 
-function getFirmwareInfo(serialNumber) {
+function getProbeInfo(serialNumber) {
+    return new Promise((resolve, reject) => {
+        nrfjprog.getProbeInfo(serialNumber, (err, probeInfo) => {
+            if (err) {
+                reject(new Error(`Failed to get probe info: ${err.message}`));
+            } else {
+                resolve(probeInfo);
+            }
+        });
+    });
+}
+
+export function getFirmwareInfo(serialNumber) {
     return new Promise((resolve, reject) => {
         firmwareUpdater.getVersionInfo(serialNumber, (err, versionInfo) => {
             if (err) {
@@ -87,24 +99,28 @@ function getFirmwareInfo(serialNumber) {
     });
 }
 
-export function getDeviceAndFirmwareInfo(serialNumber) {
+export function getAllDeviceInfo(serialNumber) {
     // By default, the nrfjprog function calls implicitly open a connection,
     // perform an operation, reset the device and close the connection to
     // the device. We are calling nrfjprog multiple times here, so we wrap
     // the function calls in open/close so that open, reset, and close are
     // only done once.
-    const deviceAndFirmwareInfo = {};
+    const allInfo = {};
     return open(serialNumber)
         .then(() => getDeviceInfo(serialNumber))
         .then(deviceInfo => {
-            deviceAndFirmwareInfo.deviceInfo = deviceInfo;
+            allInfo.deviceInfo = deviceInfo;
             return getFirmwareInfo(serialNumber);
         })
         .then(firmwareInfo => {
-            deviceAndFirmwareInfo.firmwareInfo = firmwareInfo;
+            allInfo.firmwareInfo = firmwareInfo;
+            return getProbeInfo(serialNumber);
+        })
+        .then(probeInfo => {
+            allInfo.probeInfo = probeInfo;
             return close(serialNumber);
         })
-        .then(() => deviceAndFirmwareInfo);
+        .then(() => allInfo);
 }
 
 export function programConnectivityFirmware(serialNumber) {

--- a/lib/reducers/__tests__/dfuReducer-test.js
+++ b/lib/reducers/__tests__/dfuReducer-test.js
@@ -42,7 +42,7 @@
 // they are imported by adapterActions.js, which dfuReducer.js depends on.
 jest.mock('../../utils/fileUtil', () => {});
 jest.mock('../../utils/uuid_definitions', () => {});
-jest.mock('../../api/firmware', () => {});
+jest.mock('../../api/nrfjprog', () => {});
 
 import reducer from '../dfuReducer';
 import * as DfuActions from '../../actions/dfuActions';

--- a/lib/reducers/__tests__/discoveryReducer-test.js
+++ b/lib/reducers/__tests__/discoveryReducer-test.js
@@ -41,7 +41,7 @@
 // testing.
 jest.mock('../../utils/fileUtil', () => {});
 jest.mock('../../utils/uuid_definitions', () => {});
-jest.mock('../../api/firmware', () => {});
+jest.mock('../../api/nrfjprog', () => {});
 
 import reducer from '../discoveryReducer';
 import * as DiscoveryActions from '../../actions/discoveryActions';

--- a/lib/reducers/__tests__/serverSetupReducer-test.js
+++ b/lib/reducers/__tests__/serverSetupReducer-test.js
@@ -41,7 +41,7 @@
 // testing.
 jest.mock('../../utils/fileUtil', () => {});
 jest.mock('../../utils/uuid_definitions', () => {});
-jest.mock('../../api/firmware', () => {});
+jest.mock('../../api/nrfjprog', () => {});
 
 import reducer from '../serverSetupReducer';
 import * as ServerSetupActions from '../../actions/serverSetupActions';

--- a/lib/reducers/adapterReducer.js
+++ b/lib/reducers/adapterReducer.js
@@ -107,7 +107,7 @@ function removeAdapter(oldState, adapter) {
     return state;
 }
 
-function adapterGetLocalDeviceInfo(state, deviceInfo) {
+function setLocalDeviceInfo(state, deviceInfo) {
     return state.set('deviceInfo', deviceInfo);
 }
 
@@ -380,8 +380,8 @@ export default function (oldState = getImmutableRoot(), action) {
             return adapterScanTimeout(state, action.adapter);
         case AdapterAction.ADAPTER_ADVERTISEMENT_TIMEOUT:
             return adapterAdvertisementTimeout(state, action.adapter);
-        case AdapterAction.ADAPTER_GET_LOCAL_DEVICE_INFO:
-            return adapterGetLocalDeviceInfo(state, action.deviceInfo);
+        case AdapterAction.ADAPTER_LOCAL_DEVICE_INFO_LOADED:
+            return setLocalDeviceInfo(state, action.deviceInfo);
         case AdapterAction.ERROR_OCCURED:
             return addError(state, action.error);
         case AdapterAction.DEVICE_CONNECT:


### PR DESCRIPTION
This replaces #74, which is now conflicting with master. Using open/close from pc-nrfjprog-js so that getting the probe info does not slow down opening the serial port.

Note: I took the liberty to remove the connectivity firmware's transport type from the log output as it only said "transportType: 1", which is not very informative. Let me know if we still need to log this. In that case, I think we should show what the "1" actually means.