### PR TITLE
 Fix issue when resetting and applying server setup

### DIFF
--- a/lib/actions/adapterActions.js
+++ b/lib/actions/adapterActions.js
@@ -248,13 +248,6 @@ function advertiseTimeoutAction(adapter) {
     };
 }
 
-function adapterLocalDeviceInfoLoadedAction(deviceInfo) {
-    return {
-        type: ADAPTER_LOCAL_DEVICE_INFO_LOADED,
-        deviceInfo,
-    };
-}
-
 function deviceAuthErrorOccuredAction(device) {
     return {
         type: DEVICE_AUTH_ERROR_OCCURED,
@@ -1107,13 +1100,20 @@ function closeSelectedAdapter(dispatch, getState) {
     });
 }
 
+export function localDeviceInfoLoaded(deviceInfo) {
+    return {
+        type: ADAPTER_LOCAL_DEVICE_INFO_LOADED,
+        deviceInfo,
+    };
+}
+
 export function selectedSerialPort(port) {
     return dispatch => (
         dispatch(closeAdapter(() => {
             getAllDeviceInfo(port.serialNumber)
                 .then(allDeviceInfo => {
                     const { deviceInfo, firmwareInfo, probeInfo } = allDeviceInfo;
-                    dispatch(adapterLocalDeviceInfoLoadedAction(deviceInfo));
+                    dispatch(localDeviceInfoLoaded(deviceInfo));
                     logger.info(`Device type: ${deviceTypeDefinitions[deviceInfo.deviceType]}. ` +
                         `J-Link serial number: ${probeInfo.serialNumber}. ` +
                         `J-Link firmware: ${probeInfo.firmwareString}.`);

--- a/lib/actions/serverSetupActions.js
+++ b/lib/actions/serverSetupActions.js
@@ -43,8 +43,9 @@ import { logger } from 'nrfconnect/core';
 import bleDriver from 'pc-ble-driver-js';
 
 import { getInstanceIds } from '../utils/api';
+import { getAllDeviceInfo } from './../api/nrfjprog';
 
-import { openAdapter } from './adapterActions';
+import * as AdapterActions from './adapterActions';
 import { showErrorDialog } from './errorDialogActions';
 
 import { ValidationError } from '../common/Errors';
@@ -419,16 +420,24 @@ export function applyServer() {
 
 export function resetAndApplyServer() {
     return (dispatch, getState) => {
-        const portNameToUse = getState().core.serialPort.selectedPort;
-        const portToUse = getState().core.serialPort.ports.find(x => x.comName === portNameToUse);
-        const versionInfoToUse = getState().app.adapter.versionInfo;
-        const adapterToUse = getState().app.adapter.adapters
+        const portName = getState().core.serialPort.selectedPort;
+        const port = getState().core.serialPort.ports.find(x => x.comName === portName);
+        const adapter = getState().app.adapter.adapters
             .get(getState().app.adapter.selectedAdapterIndex);
-        dispatch(openAdapter(portToUse, versionInfoToUse))
-        .then(() => {
-            dispatch(loadAction(adapterToUse.serverSetup.toJS()));
-            dispatch(applyServer());
-        });
+        const currentServerSetup = adapter.serverSetup.toJS();
+        dispatch(AdapterActions.closeAdapter(() => {
+            getAllDeviceInfo(port.serialNumber)
+                .then(allDeviceInfo => {
+                    const { deviceInfo, firmwareInfo } = allDeviceInfo;
+                    dispatch(AdapterActions.localDeviceInfoLoaded(deviceInfo));
+                    return dispatch(AdapterActions.openAdapter(port, firmwareInfo));
+                })
+                .then(() => {
+                    dispatch(loadAction(currentServerSetup));
+                    dispatch(applyServer());
+                })
+                .catch(error => logger.error(`Unable to reset and apply server setup: ${error.message}`));
+        }));
     };
 }
 


### PR DESCRIPTION
The CentralDevice and ServerSetup components require a `deviceInfo` prop. This device info needs to be loaded from nrfjprog and added to state before opening the adapter. If not, the CentralDevice and ServerSetup will fail to render.

Added a short-term fix for this in `resetAndApplyServer` now, but I think this needs to be refactored. We should not have to remember to dispatch LOCAL_DEVICE_INFO_LOADED before opening the adapter. This is easy to forget, and will lead to bugs like this. If it is required for opening the adapter, then it should probably be handled by `AdapterActions.openAdapter` instead.