### PR TITLE
 Update devdep version to fix jsx linting issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Since *nRF Connect* expects local apps in `$HOME/.nrfconnect-apps/local` (Linux/
 To build this project you will need to install the following tools:
 
 * Node.js (>=6.9)
-* npm (>=3.7.0)
+* npm (>=5.6.0) / yarn (>=1.4.0)
 
 ## Compiling
 

--- a/lib/components/__tests__/DfuEditor-test.jsx
+++ b/lib/components/__tests__/DfuEditor-test.jsx
@@ -40,6 +40,16 @@ import FileInput from '../input/FileInput';
 import DfuButton from '../DfuButton';
 import DfuEditor from '../DfuEditor';
 
+function mountComponent(props) {
+    return mount(<DfuEditor
+        isStarted={false}
+        onChooseFile={() => {}}
+        onStartDfu={() => {}}
+        onStopDfu={() => {}}
+        {...props}
+    />);
+}
+
 describe('DfuEditor', () => {
     describe('when choose file button is clicked', () => {
         const onChooseFile = jest.fn();
@@ -85,12 +95,3 @@ describe('DfuEditor', () => {
     });
 });
 
-function mountComponent(props) {
-    return mount(<DfuEditor
-        isStarted={false}
-        onChooseFile={() => {}}
-        onStartDfu={() => {}}
-        onStopDfu={() => {}}
-        {...props}
-    />)
-}

--- a/lib/components/__tests__/ServiceItem-test.jsx
+++ b/lib/components/__tests__/ServiceItem-test.jsx
@@ -36,13 +36,9 @@
 
 /* eslint-disable import/first */
 
-jest.mock('../../utils/colorDefinitions', () => {
-    return {
-        getColor: () => {
-            return {r: 255, g: 255, b: 255}
-        }
-    };
-});
+jest.mock('../../utils/colorDefinitions', () => ({
+    getColor: () => ({ r: 255, g: 255, b: 255 }),
+}));
 jest.mock('../../utils/uuid_definitions', () => {});
 
 import React from 'react';

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jquery": "^3.2.1",
     "lodash.throttle": "^4.1.1",
     "mousetrap": "^1.6.1",
-    "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#v1.1.0",
+    "pc-nrfconnect-devdep": "https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:^1.2.2",
     "react-d3-components": "^0.6.6",
     "react-onclickoutside": "^5.10.0",
     "react-sizeme": "^2.3.1",


### PR DESCRIPTION
Also now using semver caret in dependency, so that we get new patch or minor versions automatically. Fixed some previously undetected linting errors in tests.