### PR TITLE
Hide menu items in the server setup view

### DIFF
--- a/lib/components/CentralDevice.jsx
+++ b/lib/components/CentralDevice.jsx
@@ -118,7 +118,9 @@ class CentralDevice extends React.PureComponent {
             bindHotkey,
         } = this.props;
 
-        bindHotkey('alt+a', onToggleAdvertising);
+        if (onToggleAdvertising) {
+            bindHotkey('alt+a', onToggleAdvertising);
+        }
 
         const style = {
             position: 'relative',

--- a/lib/components/CentralDevice.jsx
+++ b/lib/components/CentralDevice.jsx
@@ -140,16 +140,13 @@ class CentralDevice extends React.PureComponent {
         const dropDownMenuItems = (() => {
             const items = [];
 
-            if (onToggleAdvertising !== undefined) {
+            if (onToggleAdvertising) {
                 items.push(<MenuItem key="advHeader" header>Advertising</MenuItem>);
-                if (advertising !== undefined) {
-                    items.push(
-                        <MenuItem key="setup" eventKey="AdvertisingSetup">
-                            Advertising setup...
-                        </MenuItem>,
-                    );
-                }
-
+                items.push(
+                    <MenuItem key="setup" eventKey="AdvertisingSetup">
+                        Advertising setup...
+                    </MenuItem>,
+                );
                 items.push(
                     <MenuItem key="advertising" eventKey="ToggleAdvertising">
                         {advMenuText} <span className="subtler-text">(Alt+A)</span>
@@ -157,15 +154,15 @@ class CentralDevice extends React.PureComponent {
                 );
             }
 
-            if (onLoadSetup !== undefined) {
+            if (onLoadSetup) {
                 items.push(<MenuItem key="load" eventKey="LoadSetup">Load setup...</MenuItem>);
             }
 
-            if (onSaveSetup !== undefined) {
+            if (onSaveSetup) {
                 items.push(<MenuItem key="save" eventKey="SaveSetup">Save setup...</MenuItem>);
             }
 
-            if (onToggleAutoConnUpdate !== undefined) {
+            if (onToggleAutoConnUpdate) {
                 items.push(<MenuItem key="dividerConnUpdate" divider />);
                 items.push(<MenuItem key="connUpdateHeader" header>Connection update</MenuItem>);
                 items.push(
@@ -179,8 +176,8 @@ class CentralDevice extends React.PureComponent {
                 );
             }
 
-            if (onToggleAutoAcceptPairing !== undefined &&
-                onShowSecurityParamsDialog !== undefined) {
+            if (onToggleAutoAcceptPairing &&
+                onShowSecurityParamsDialog) {
                 items.push(<MenuItem key="dividerSecurity" divider />);
                 items.push(<MenuItem key="securityHeader" header>Security</MenuItem>);
                 items.push(
@@ -212,7 +209,7 @@ class CentralDevice extends React.PureComponent {
                 );
             }
 
-            if (onOpenCustomUuidFile !== undefined) {
+            if (onOpenCustomUuidFile) {
                 items.push(<MenuItem key="dividerOpenUuidFile" divider />);
                 items.push(
                     <MenuItem key="headerOpenUuidFile" header>Custom UUID definitions</MenuItem>,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-ble",
-  "version": "2.2.0-alpha.0",
+  "version": "2.2.0-alpha.1",
   "description": "A natural first choice for Bluetooth Low Energy development",
   "displayName": "Bluetooth Low Energy",
   "repository": {


### PR DESCRIPTION
Many menu items were unintentionally shown in the server setup view, and clicking the items did not work. This is a bug that was introduced in the standalone application -> nRF Connect app rewrite. Fixing this.

Before fix:

![image](https://user-images.githubusercontent.com/461755/41146231-fd3f6010-6b02-11e8-93b7-039e4f8a7a95.png)

After fix:

![image](https://user-images.githubusercontent.com/461755/41146158-bc5a7a76-6b02-11e8-8f77-caee4b1c9c5d.png)