### PR TITLE
Fix ADV packet update by merging existing and new

### DIFF
--- a/lib/reducers/discoveryReducer.js
+++ b/lib/reducers/discoveryReducer.js
@@ -112,7 +112,10 @@ function deviceDiscovered(oldState, device) {
             newDevice = newDevice.setIn(['services'], existingDevice.services);
         }
         newDevice = newDevice.setIn(['isExpanded'], existingDevice.isExpanded);
-        newDevice = newDevice.mergeIn(['adData'], existingDevice.adData);
+
+        // Merge existing adData with new to keep everything that is not updated
+        const adData = existingDevice.adData.merge(newDevice.adData);
+        newDevice = newDevice.mergeIn(['adData'], adData);
     }
     if (newDevice.name === null) {
         newDevice = newDevice.setIn(['name'], '');


### PR DESCRIPTION
This is my proposal to address issue #95, whereas in the old solution neither the direction nor the level of merge was sufficient. This solution however would not reflect if some field gets deleted from the advertisement.