### PR TITLE
Improve attribute throttling mechanism

### DIFF
--- a/lib/actions/adapterActions.js
+++ b/lib/actions/adapterActions.js
@@ -99,6 +99,7 @@ export const DEVICE_ENABLE_EVENTS = 'DEVICE_ENABLE_EVENTS';
 export const ERROR_OCCURED = 'ERROR_OCCURED';
 
 export const ATTRIBUTE_VALUE_CHANGED = 'ADAPTER_ATTRIBUTE_VALUE_CHANGED';
+export const MULTI_ATTRIBUTE_VALUE_CHANGED = 'ADAPTER_MULTI_ATTRIBUTE_VALUE_CHANGED';
 
 export const TRACE = 0;
 export const DEBUG = 1;
@@ -128,6 +129,7 @@ const secKeyset = {
 };
 
 let throttledValueChangedDispatch;
+const attributeValueArray = [];
 
 function adapterOpenedAction(adapter) {
     return {
@@ -336,11 +338,10 @@ function securityChangedAction(device, parameters) {
     };
 }
 
-function attributeValueChangedAction(attribute, value) {
+function multiAttributeValueChangedAction(attributeValueArr) {
     return {
-        type: ATTRIBUTE_VALUE_CHANGED,
-        attribute,
-        value,
+        type: MULTI_ATTRIBUTE_VALUE_CHANGED,
+        attributeValueArray: attributeValueArr,
     };
 }
 
@@ -601,6 +602,13 @@ function onDeviceConnected(dispatch, getState, device) {
     dispatch(discoverServices(device));
 }
 
+function multiValueChangedDispatch(dispatch) {
+    // Using slice operator to create a copy of the array before the original is cleared.
+    const attrValArrCopy = attributeValueArray.slice();
+    dispatch(multiAttributeValueChangedAction(attrValArrCopy));
+    attributeValueArray.length = 0; // Clearing the array
+}
+
 function onAttributeValueChanged(dispatch, getState, attribute, handle) {
     let val;
     if (Array.isArray(attribute.value)) {
@@ -612,12 +620,11 @@ function onAttributeValueChanged(dispatch, getState, attribute, handle) {
     logger.info(`Attribute value changed, handle: 0x${toHexString(handle)}, value (0x): ${toHexString(val)}`);
 
     if (!throttledValueChangedDispatch) {
-        throttledValueChangedDispatch = _.throttle((attribute2, value) => {
-            dispatch(attributeValueChangedAction(attribute2, value));
-        }, 500);
+        throttledValueChangedDispatch = _.throttle(multiValueChangedDispatch, 500);
     }
 
-    throttledValueChangedDispatch(attribute, attribute.value);
+    attributeValueArray.push({ attribute, value: attribute.value });
+    throttledValueChangedDispatch(dispatch);
 }
 
 function onConnParamUpdateRequest(dispatch, getState, device, requestedConnectionParams) {

--- a/lib/reducers/deviceDetailsReducer.js
+++ b/lib/reducers/deviceDetailsReducer.js
@@ -296,6 +296,17 @@ function attributeValueChanged(oldState, attribute, value, error) {
     return state;
 }
 
+function multiAttributeValuteChange(oldstate, attributeValueArray) {
+    // Reducing the array of attributes by calling attributeValueChanged
+    // and feeding the resulting state into the next call.
+    const reducer = (accumulatorState, currentValue) => {
+        const { attribute, value } = currentValue;
+        return attributeValueChanged(accumulatorState, attribute, value);
+    };
+
+    return attributeValueArray.reduce(reducer, oldstate);
+}
+
 function appliedServerSetup(state, services) {
     let localDeviceDetails = new DeviceDetail({ children: new OrderedMap() });
 
@@ -356,6 +367,8 @@ export default function deviceDetails(state = initialState, action) {
             return appliedServerSetup(state, action.services);
         case AdapterActions.ATTRIBUTE_VALUE_CHANGED:
             return attributeValueChanged(state, action.attribute, action.value);
+        case AdapterActions.MULTI_ATTRIBUTE_VALUE_CHANGED:
+            return multiAttributeValuteChange(state, action.attributeValueArray);
         case AdapterActions.DEVICE_CONNECTED:
             return state.setIn(['devices', action.device.instanceId], new DeviceDetail());
         case AdapterActions.ADAPTER_CLOSED:


### PR DESCRIPTION
Add better handling of attribute updates for the case when updates are received for multiple attributes within the same throttling interval. This is handled by batching together updates instead of masking them out.