### PR TITLE
Fix binding of keyboard shortcuts

### DIFF
--- a/lib/components/CentralDevice.jsx
+++ b/lib/components/CentralDevice.jsx
@@ -51,6 +51,9 @@ class CentralDevice extends React.PureComponent {
     constructor(props) {
         super(props);
         this.onSelect = this.onSelect.bind(this);
+    }
+
+    componentDidMount() {
         const { bindHotkey, onToggleAdvertising } = this.props;
         if (onToggleAdvertising) {
             bindHotkey('alt+a', onToggleAdvertising);

--- a/lib/containers/DiscoveredDevices.jsx
+++ b/lib/containers/DiscoveredDevices.jsx
@@ -65,6 +65,13 @@ class DiscoveredDevices extends React.PureComponent {
         this.handleSortByRssiCheckedChange = this.handleCheckedChange.bind(this, 'sortByRssi');
     }
 
+    componentDidMount() {
+        const { bindHotkey, clearDevicesList } = this.props;
+        if (clearDevicesList) {
+            bindHotkey('alt+c', clearDevicesList);
+        }
+    }
+
     handleCheckedChange(property, e) {
         const { setDiscoveryOptions } = this.props;
         this.discoveryOptions[property] = e.target.checked;
@@ -95,10 +102,7 @@ class DiscoveredDevices extends React.PureComponent {
             cancelConnect,
             toggleExpanded,
             toggleOptionsExpanded,
-            bindHotkey,
         } = this.props;
-
-        bindHotkey('alt+c', clearDevicesList);
 
         this.discoveryOptions = discoveryOptions.toJS();
 


### PR DESCRIPTION
This PR fixes lost Alt+A shortcut by moving the binding to the correct lifecycle method.
Alt+C is also moved for consistency, there's no need to repeat the binding for every render.