### PR TITLE
Simplify selected view height

### DIFF
--- a/lib/components/SelectedView.jsx
+++ b/lib/components/SelectedView.jsx
@@ -45,59 +45,16 @@ import ServerSetup from '../containers/ServerSetup';
 const DEVICE_DETAILS_VIEW_ID = 0;
 const SERVER_SETUP_VIEW_ID = 1;
 
-class SelectedView extends React.PureComponent {
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            windowHeight: window.innerHeight,
-        };
+const SelectedView = ({ viewId }) => {
+    switch (viewId) {
+        case DEVICE_DETAILS_VIEW_ID:
+            return <DeviceDetailsContainer />;
+        case SERVER_SETUP_VIEW_ID:
+            return <ServerSetup />;
+        default:
     }
-
-    componentWillMount() {
-        (() => {
-            const throttle = (type, name, obj) => {
-                let running = false;
-                const object = obj || window;
-                const func = () => {
-                    if (running) {
-                        return;
-                    }
-
-                    running = true;
-                    requestAnimationFrame(() => {
-                        object.dispatchEvent(new CustomEvent(name));
-                        running = false;
-                    });
-                };
-
-                object.addEventListener(type, func);
-            };
-
-            throttle('resize', 'optimizedResize');
-        })();
-
-        // handle event
-        window.addEventListener('optimizedResize', () => {
-            this.setState({ windowHeight: window.innerHeight });
-        });
-    }
-
-    render() {
-        const { viewId } = this.props;
-        const { windowHeight } = this.state;
-        const topBarHeight = 55;
-        const layoutStyle = { height: windowHeight - topBarHeight };
-        const mainAreaHeight = layoutStyle.height - 189;
-
-        if (viewId === DEVICE_DETAILS_VIEW_ID) {
-            return <DeviceDetailsContainer style={{ height: mainAreaHeight }} />;
-        } if (viewId === SERVER_SETUP_VIEW_ID) {
-            return <ServerSetup style={{ height: mainAreaHeight }} />;
-        }
-        return null;
-    }
-}
+    return null;
+};
 
 SelectedView.propTypes = {
     viewId: PropTypes.number.isRequired,

--- a/lib/containers/DeviceDetails.jsx
+++ b/lib/containers/DeviceDetails.jsx
@@ -161,14 +161,13 @@ class DeviceDetailsContainer extends React.PureComponent {
             security,
             openCustomUuidFile,
             showDfuDialog,
-            style,
         } = this.props;
 
         const elemWidth = 250;
         const detailDevices = [];
 
         if (!adapterState) {
-            return <div className="device-details-container" style={style} />;
+            return <div className="device-details-container" />;
         }
 
         // Details for connected adapter
@@ -226,7 +225,7 @@ class DeviceDetailsContainer extends React.PureComponent {
         // TODO: Fix better solution to right padding of scroll area than div box with border
         return (
             <div>
-                <div className="device-details-container" style={style}>
+                <div className="device-details-container">
                     <div style={{ width }}>
                         {detailDevices}
                         <div style={{
@@ -307,7 +306,6 @@ DeviceDetailsContainer.propTypes = {
     toggleAutoConnUpdate: PropTypes.func.isRequired,
     autoConnUpdate: PropTypes.bool,
     showDfuDialog: PropTypes.func.isRequired,
-    style: PropTypes.object.isRequired,
     bindHotkey: PropTypes.func.isRequired,
 };
 

--- a/lib/containers/ServerSetup.jsx
+++ b/lib/containers/ServerSetup.jsx
@@ -277,11 +277,10 @@ class ServerSetup extends React.PureComponent {
             showErrorDialog,
             // showDiscardDialog,
             // hideDiscardDialog,
-            style,
         } = this.props;
 
         if (!serverSetup) {
-            return (<div className="server-setup" style={style} />);
+            return (<div className="server-setup" />);
         }
         const {
             selectedComponent,
@@ -388,7 +387,7 @@ class ServerSetup extends React.PureComponent {
         );
 
         return (
-            <div className="server-setup" style={style}>
+            <div className="server-setup">
                 <div className="server-setup-view">
                     <div className="server-setup-tree">
                         {central}
@@ -516,7 +515,6 @@ ServerSetup.propTypes = {
     hideClearDialog: PropTypes.func.isRequired,
     showErrorDialog: PropTypes.func.isRequired,
     toggleAdvertising: PropTypes.func,
-    style: PropTypes.object.isRequired,
     bindHotkey: PropTypes.func.isRequired,
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-ble",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A natural first choice for Bluetooth Low Energy development",
   "displayName": "Bluetooth Low Energy",
   "repository": {

--- a/resources/css/styles.scss
+++ b/resources/css/styles.scss
@@ -806,9 +806,11 @@
 
 .server-setup {
     padding: 20px;
+    height: 100%;
 }
 
 .device-details-container {
+    height: 100%;
     .local-server {
         margin: 0px;
     }


### PR DESCRIPTION
This PR solves the issue of inconsistency with rendering the selected view new electron version.
The calculation of the view's height in js code is not necessary, using a simple css rule works with both electron 2 and 5.