### PR TITLE
Fix keypress notification display

### DIFF
--- a/lib/components/AuthKeyEditor.jsx
+++ b/lib/components/AuthKeyEditor.jsx
@@ -448,8 +448,6 @@ class AuthKeyEditor extends React.PureComponent {
                 controls = this.createPasskeyDisplayControls(
                     event.authKeyParams.passkey,
                     event.receiveKeypressEnabled,
-                    event.keypressStartReceived,
-                    event.keypressEndReceived,
                     event.keypressCount,
                 );
                 break;


### PR DESCRIPTION
There was a mismatch in arguments of `AuthKeyEditor.createPasskeyDisplayControls` between call site and definition.