### PR TITLE
Fix broken pairing and server setup

### DIFF
--- a/lib/utils/api.js
+++ b/lib/utils/api.js
@@ -57,9 +57,9 @@ export const ImmutableAdapter = Record({
     state: new ImmutableAdapterState(),
     connectedDevices: Map(),
     /* Adapter sub-reducers */
-    deviceDetails: null,
-    serverSetup: null,
-    security: null,
+    deviceDetails: undefined,
+    serverSetup: undefined,
+    security: undefined,
     isServerSetupApplied: false,
 });
 


### PR DESCRIPTION
This fixes [NCP-2734](https://projecttools.nordicsemi.no/jira/browse/NCP-2734) and [NCP-2735](https://projecttools.nordicsemi.no/jira/browse/NCP-2735): Neither the pairing dialog nor the device in the server setup showed up
anymore.

This was caused by a breaking change in immutable. With this code:

    const MyRecord = Record({k: null})
    const t1 = MyRecord({})
    const t2 = MyRecord({k: undefined})

In immutable 3 in object `t1` the property `k` contained `null` (the
default value) while in `t2` it contained `undefined`. Thus in
immutable 3 default values were only used if a property was not
specified at all.

This changed in immutable 4: Here both `t1` and `t2` will contain `null`
for the property `k`. Thus default values are used if a property is not
specified at all or if it containes `undefined`.

In `lib/utils/api.js` we also used `null` as default values for
`deviceDetails`, `serverSetup` and `security`, which was wrong. They
must be `undefined` later on, so that the corresponding reducers use
their default states.