### PR TITLE
Pairing was unpossible

### DIFF
--- a/lib/reducers/securityReducer.js
+++ b/lib/reducers/securityReducer.js
@@ -36,7 +36,7 @@
 
 'use strict';
 
-import Immutable, { Record } from 'immutable';
+import Immutable, { Map, Record } from 'immutable';
 import { logger } from 'nrfconnect/core';
 
 import * as SecurityActions from '../actions/securityActions';


### PR DESCRIPTION
Fixes [NCP-2734](https://projecttools.nordicsemi.no/jira/browse/NCP-2734).

When trying to complete a pairing an error message was instead shown:

> Error when calling 'reduceApp': Cannot update within non-data-structure
> value in path ["connectionsSecParameters"]: [object Map]

This was caused by a combination of an old bug in the code and a change
in immutable-js 4:

In the old code an import for the Map of immutable was missing, which
meant in lib/reducers/securityReducer.js the Map of JavaScript was used
instead.

immutable-js 3 did work with the JavaScript variant of Map, but in a
questionable way, because it really mutated it, which means also other,
supposedly unmutable objects were mutated. immutable-js 4 now rejects
such mutation attempts as an error.