### PR TITLE
Fix creating characteristics in the server setup

### DIFF
--- a/lib/reducers/__tests__/serverSetupReducer-test.js
+++ b/lib/reducers/__tests__/serverSetupReducer-test.js
@@ -188,7 +188,7 @@ describe('serverSetupReducer', () => {
             const gapService = state.children.first();
             const deviceNameCharacteristic = gapService.children.first();
 
-            expect(deviceNameCharacteristic.value).toEqual([0x01, 0x02, 0x03]);
+            expect(deviceNameCharacteristic.value.toArray()).toEqual([0x01, 0x02, 0x03]);
         });
     });
 

--- a/lib/reducers/serverSetupReducer.js
+++ b/lib/reducers/serverSetupReducer.js
@@ -36,7 +36,7 @@
 
 'use strict';
 
-import { Record, OrderedMap } from 'immutable';
+import { Record, OrderedMap, List } from 'immutable';
 import { logger } from 'nrfconnect/core';
 
 import * as ServerSetupActions from '../actions/serverSetupActions';
@@ -281,6 +281,9 @@ function changedAttribute(state, attribute) {
     const attr = attribute;
     if (attr.properties) {
         attr.properties = getImmutableProperties(attr.properties);
+    }
+    if (Array.isArray(attr.value)) {
+        attr.value = List(attr.value);
     }
 
     return state.mergeIn(attributeStatePath, attr);


### PR DESCRIPTION
Fixes [NCP-2740](https://projecttools.nordicsemi.no/jira/browse/NCP-2740):

Creating and saving a characteristic crashed the whole app.

This was caused by a subtle change in immutable: When merging in
properties that contain an array immutable before converted them to
instances of List. Now it keeps them as arrays. But for value we
depended elsewhere on it being a List.