### PR TITLE
Downgrade immutable

### DIFF
--- a/lib/reducers/__tests__/serverSetupReducer-test.js
+++ b/lib/reducers/__tests__/serverSetupReducer-test.js
@@ -188,7 +188,7 @@ describe('serverSetupReducer', () => {
             const gapService = state.children.first();
             const deviceNameCharacteristic = gapService.children.first();
 
-            expect(deviceNameCharacteristic.value).toEqual([0x01, 0x02, 0x03]);
+            expect(deviceNameCharacteristic.value.toArray()).toEqual([0x01, 0x02, 0x03]);
         });
     });
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "change-case": "^3.0.1",
     "d3": "^4.7.4",
+    "immutable": "^3.8.2",
     "jquery": "^3.2.1",
     "lodash.throttle": "^4.1.1",
     "mousetrap": "^1.6.1",


### PR DESCRIPTION
The newer release 4.0.0-rc12 (coming in through a transitive dependency
from pc-nrfconnect-devdep) brings in several bugs and we are uncertain
whether there are more. So we try a downgrade to the stable version to
see whether that works better.