### PR TITLE
Scan results wrongly showed advertisement keys

### DIFF
--- a/lib/components/DiscoveredDevice.jsx
+++ b/lib/components/DiscoveredDevice.jsx
@@ -203,6 +203,7 @@ class DiscoveredDevice extends React.PureComponent {
                                     </div>
                                 );
                             })
+                            .values()
                     }
                 </div>
             );


### PR DESCRIPTION
Before 

> ![Scan result - broken](https://user-images.githubusercontent.com/260705/68764542-33227000-061b-11ea-968c-dac2ef97d744.png)

Now:

> ![Scan result](https://user-images.githubusercontent.com/260705/68764561-387fba80-061b-11ea-8825-6775eb07c652.png)
