### PR TITLE
Changelog as release notes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,51 @@
+## Version 2.3.2
+### Features
+- Support nRF52833 #137
+### Bugfixes
+- Fixed partly shown dropdown #132
+- Scan results wrongly showed advertisement keys #143
+- Fixed keypress notification display
+
+## Version 2.3.1
+### Bugfixes
+- Fixed window content height to avoid scrolling
+
+## Version 2.3.0
+### Updates
+- Updated to React Bootstrap 4
+
+## Version 2.2.1
+### Updates
+- Updated README.md specifying nRF52840 for kit and dongle #94
+- Added filter for supported devices #100
+### Bugfixes
+- Fixed ADV packet update by merging existing and new #97
+- Fixed advertising shortcut #99
+- Fixed unexpected line in connected view #102
+- Fixed attribute throttling mechanism #98 #101
+
+## Version 2.1.0
+### Features
+- Server setup can be applied multiple times with adapter reset (#65, #82)
+- Log J-Link firmware string when selecting serial port (#81)
+### Bugfixes
+- Keep connection open when performing DFU (#77)
+- Fix issue with custom UUIDs interfering with normal behavior (#54)
+- UTF8 support (#60)
+
+## Version 2.0.1
+### Bugfixes
+- Fix issue with custom UUIDs interfering with normal behavior (#54)
+
+## Version 2.0.0
+The main change of this release is that the tool has been rewritten as an app for nRF Connect v2.0. It is no longer a standalone application, but should be installed and launched from nRF Connect.
+### Features
+- Add Thingy UUIDs (#37)
+- Buttonless DFU (#47)
+### Bugfixes
+- Increase device name max length in advertising data (#20)
+- Better error message when connection lost during service discovery (#39)
+
+## Version 1.1.1
+- #16 Issue with blank screen if VC++ redistributable is not installed
+- #18 Issue at startup when settings.json is invalid

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jquery": "^3.2.1",
     "lodash.throttle": "^4.1.1",
     "mousetrap": "^1.6.1",
-    "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:^3.1.0",
+    "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:3.3.0",
     "react-d3-components": "^0.9.1",
     "react-onclickoutside": "^5.10.0",
     "react-sizeme": "^2.3.1",


### PR DESCRIPTION
This is part of [NCP-2820](https://projecttools.nordicsemi.no/jira/browse/NCP-2820). The whole concept is described there.

This changes two things:
- It adds a `Changelog.md` which contains all entries that were previously in the GitHub releases.
- It references devdep 3.3 so that future releases of this app will also upload the `Changelog.md` to developer.nordicsemi.com.

Because this changes depends on the release of devdep 3.3, this PR is created as a draft PR and  will be marked as being ready later when NordicSemiconductor/pc-nrfconnect-devdep#26 is merged and devdep 3.3 is released.