### PR TITLE
Harden against new serialport

### DIFF
--- a/lib/actions/adapterActions.js
+++ b/lib/actions/adapterActions.js
@@ -1180,20 +1180,21 @@ export function initAdapter(device) {
     return dispatch => {
         if (device.serialport) {
             const { serialNumber } = device;
-            const { comName } = device.serialport;
+            // Prefer to use the serialport 8 property or fall back to the serialport 7 property
+            const portPath = device.serialport.path || device.serialport.comName;
 
             if (device.traits.includes('jlink')) {
                 if (isSupportedJLinkDevice(device.boardVersion)) {
-                    dispatch(openJlinkAdapter(comName, serialNumber));
+                    dispatch(openJlinkAdapter(portPath, serialNumber));
                 } else {
                     logger.info('The device is not in the list of supported devices. '
                         + 'Attempting to open as a custom device.');
-                    dispatch(openCustomAdapter(comName));
+                    dispatch(openCustomAdapter(portPath));
                 }
             } else if (device.traits.includes('nordicUsb')) {
-                dispatch(openNordicUsbAdapter(comName));
+                dispatch(openNordicUsbAdapter(portPath));
             } else {
-                dispatch(openCustomAdapter(comName));
+                dispatch(openCustomAdapter(portPath));
             }
         } else {
             logger.error('Device has no serial port. Cannot open device.');

--- a/lib/actions/adapterActions.js
+++ b/lib/actions/adapterActions.js
@@ -1050,12 +1050,12 @@ function closeSelectedAdapter(dispatch, getState) {
  * Creates and opens a pc-ble-driver-js adapter with the given serial
  * port COM name and device family.
  *
- * @param {String} comName Serial port COM name, e.g. COM1, /dev/ttyACM0
+ * @param {String} portPath Serial port COM name, e.g. COM1, /dev/ttyACM0
  * @param {Number} baudRate The baud rate to use when opening the serial port.
  * @param {Number} sdBleApiVersion SoftDevice version number.
  * @returns {function(*)} Function that can be passed to redux dispatch.
  */
-export function openAdapter(comName, baudRate, sdBleApiVersion) {
+export function openAdapter(portPath, baudRate, sdBleApiVersion) {
     return (dispatch, getState) => (
         Promise.resolve()
             .then(() => {
@@ -1066,7 +1066,7 @@ export function openAdapter(comName, baudRate, sdBleApiVersion) {
                 return Promise.resolve();
             })
             .then(() => {
-                const adapter = adapterFactory.createAdapter(`v${sdBleApiVersion}`, comName, comName);
+                const adapter = adapterFactory.createAdapter(`v${sdBleApiVersion}`, portPath, portPath);
                 dispatch(adapterOpenAction(adapter));
                 setupListeners(dispatch, getState, adapter);
 
@@ -1103,11 +1103,11 @@ export function openAdapter(comName, baudRate, sdBleApiVersion) {
  * Creates and opens a pc-ble-driver-js adapter for a J-Link device with the
  * given serial port COM name and J-Link serial number.
  *
- * @param {String} comName Serial port COM name, e.g. COM1, /dev/ttyACM0
+ * @param {String} portPath Serial port COM name, e.g. COM1, /dev/ttyACM0
  * @param {String|Number} serialNumber J-Link serial number.
  * @returns {function(*)} Function that can be passed to redux dispatch.
  */
-export function openJlinkAdapter(comName, serialNumber) {
+export function openJlinkAdapter(portPath, serialNumber) {
     return dispatch => {
         if (os.platform() === 'darwin' || os.platform() === 'linux') {
             logger.info('Note: Adapters with Segger JLink debug probe requires MSD to be disabled to function properly on MacOS and Linux. '
@@ -1123,7 +1123,7 @@ export function openJlinkAdapter(comName, serialNumber) {
                         .getJlinkConnectivityFirmware(jlinkDeviceInfo.family);
                     logger.info(`Connectivity firmware version: ${version}. `
                         + `SoftDevice API version: ${sdBleApiVersion}. Baud rate: ${baudRate}.`);
-                    dispatch(openAdapter(comName, baudRate, sdBleApiVersion));
+                    dispatch(openAdapter(portPath, baudRate, sdBleApiVersion));
                 } catch (error) {
                     logger.error(`Unable to open device: ${error.message}`);
                 }
@@ -1135,16 +1135,16 @@ export function openJlinkAdapter(comName, serialNumber) {
  * Creates and opens a pc-ble-driver-js adapter for a Nordic USB device with
  * the given serial port COM name.
  *
- * @param {String} comName Serial port COM name, e.g. COM1, /dev/ttyACM0
+ * @param {String} portPath Serial port COM name, e.g. COM1, /dev/ttyACM0
  * @returns {function(*)} Function that can be passed to redux dispatch.
  */
-export function openNordicUsbAdapter(comName) {
+export function openNordicUsbAdapter(portPath) {
     return dispatch => {
         const { version, baudRate, sdBleApiVersion } = FirmwareRegistry
             .getNordicUsbConnectivityFirmware();
         logger.info(`Connectivity firmware version: ${version}. `
             + `SoftDevice API version: ${sdBleApiVersion}. Baud rate: ${baudRate}.`);
-        dispatch(openAdapter(comName, baudRate, sdBleApiVersion));
+        dispatch(openAdapter(portPath, baudRate, sdBleApiVersion));
     };
 }
 
@@ -1152,10 +1152,10 @@ export function openNordicUsbAdapter(comName) {
  * Creates and opens a pc-ble-driver-js adapter for a custom device with
  * the given serial port COM name.
  *
- * @param {String} comName Serial port COM name, e.g. COM1, /dev/ttyACM0
+ * @param {String} portPath Serial port COM name, e.g. COM1, /dev/ttyACM0
  * @returns {function(*)} Function that can be passed to redux dispatch.
  */
-export function openCustomAdapter(comName) {
+export function openCustomAdapter(portPath) {
     return dispatch => {
         // Get firmware version and SoftDevice API version from JS library
         // Nothing to do with Nordic USB device and linux.
@@ -1166,7 +1166,7 @@ export function openCustomAdapter(comName) {
             + `connectivity firmware version: ${version}, `
             + `SoftDevice API version: ${sdBleApiVersion} and `
             + `baud rate: ${baudRate}.`);
-        dispatch(openAdapter(comName, baudRate, sdBleApiVersion));
+        dispatch(openAdapter(portPath, baudRate, sdBleApiVersion));
     };
 }
 


### PR DESCRIPTION
Part of [NCP-2996](https://projecttools.nordicsemi.no/jira/browse/NCP-2996).

This enables the app to run with either serialport 7 (which had comName as a property) or serialport 8 (which moved to the property path and warns when still using comName).