### PR TITLE
Fix/destructive filter

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Version 2.4.1
+### Bugfixes
+- Fixed destructive scan filtering
+
 ## Version 2.4.0
 ### Features
 - Added UI to control 2 Mb/s phy, data length and ATT MTU #152

--- a/lib/containers/DiscoveredDevices.jsx
+++ b/lib/containers/DiscoveredDevices.jsx
@@ -53,6 +53,14 @@ import Spinner from '../components/Spinner';
 import { DiscoveryOptions } from '../reducers/discoveryReducer';
 import withHotkey from '../utils/withHotkey';
 
+const matchesFilter = filterRegexp => (
+    device => {
+        if (device.name.search(filterRegexp) >= 0) return true;
+        if (device.address.search(filterRegexp) >= 0) return true;
+        return false;
+    }
+);
+
 class DiscoveredDevices extends React.PureComponent {
     constructor(props) {
         super(props);
@@ -132,6 +140,13 @@ class DiscoveredDevices extends React.PureComponent {
             </div>
         ) : null;
 
+        let discoveredDeviceList = discoveredDevices.valueSeq();
+
+        const { filterRegexp } = discoveryOptions;
+        if (filterRegexp) {
+            discoveredDeviceList = discoveredDeviceList.filter(matchesFilter(filterRegexp));
+        }
+
         return (
             <div id="discoveredDevicesContainer">
                 <div>
@@ -173,7 +188,7 @@ class DiscoveredDevices extends React.PureComponent {
 
                 <div style={{ paddingTop: '0px' }}>
                     {
-                        discoveredDevices.valueSeq().map((device, address) => {
+                        discoveredDeviceList.map((device, address) => {
                             const key = `${address}`;
                             return (
                                 <DiscoveredDevice

--- a/lib/reducers/discoveryReducer.js
+++ b/lib/reducers/discoveryReducer.js
@@ -43,8 +43,6 @@ import * as DiscoveryAction from '../actions/discoveryActions';
 import * as AdapterAction from '../actions/adapterActions';
 import * as apiHelper from '../utils/api';
 
-let filterRegexp;
-
 export const DiscoveryOptions = Record({
     expanded: false,
     sortByRssi: false,
@@ -53,6 +51,7 @@ export const DiscoveryOptions = Record({
     scanWindow: 20,
     scanTimeout: 60,
     activeScan: true,
+    filterRegexp: '',
 });
 
 const InitialState = Record({
@@ -75,14 +74,6 @@ function scanStopped(state) {
 
 function applyFilters(oldState) {
     let state = oldState;
-    if (filterRegexp) {
-        const filteredDevices = state.devices.filter(device => {
-            if (device.name.search(filterRegexp) >= 0) return true;
-            if (device.address.search(filterRegexp) >= 0) return true;
-            return false;
-        });
-        state = state.set('devices', filteredDevices);
-    }
 
     if (state.options.sortByRssi) {
         const orderedDevices = state.devices.sort((dev1, dev2) => {
@@ -177,8 +168,11 @@ function toggleOptionsExpanded(state) {
 }
 
 function discoverySetOptions(state, options) {
-    filterRegexp = new RegExp(options.filterString, 'i');
-    return applyFilters(state.set('options', new DiscoveryOptions(options)));
+    const newOptions = {
+        ...options,
+        filterRegexp: new RegExp(options.filterString, 'i'),
+    };
+    return applyFilters(state.set('options', new DiscoveryOptions(newOptions)));
 }
 
 export default function discovery(state = initialState, action) {


### PR DESCRIPTION
This change should fix the filtering of discovered devices. Before this change we will update the state with the filtered devices, meaning that if we remove the filter again, we will not be able to see devices that are already filtered away. 

This will also affect the issue described in pull request https://github.com/NordicSemiconductor/pc-nrfconnect-ble/pull/162, resetting the filter whenever a device is closed/opened again.