### PR TITLE
Remove the server setup discard dialog

### DIFF
--- a/lib/actions/serverSetupActions.js
+++ b/lib/actions/serverSetupActions.js
@@ -70,9 +70,6 @@ export const HIDE_DELETE_DIALOG = 'SERVER_SETUP_HIDE_DELETE_DIALOG';
 export const SHOW_CLEAR_DIALOG = 'SERVER_SETUP_SHOW_CLEAR_DIALOG';
 export const HIDE_CLEAR_DIALOG = 'SERVER_SETUP_HIDE_CLEAR_DIALOG';
 
-export const SHOW_DISCARD_DIALOG = 'SERVER_SETUP_SHOW_DISCARD_DIALOG';
-export const HIDE_DISCARD_DIALOG = 'SERVER_SETUP_DISCARD_DIALOG';
-
 export const LOAD = 'SERVER_SETUP_LOAD';
 
 const SCCD_UUID = '2903';
@@ -172,18 +169,6 @@ function showClearDialogAction() {
 function hideClearDialogAction() {
     return {
         type: HIDE_CLEAR_DIALOG,
-    };
-}
-
-function showDiscardDialogAction() {
-    return {
-        type: SHOW_DISCARD_DIALOG,
-    };
-}
-
-function hideDiscardDialogAction() {
-    return {
-        type: HIDE_DISCARD_DIALOG,
     };
 }
 
@@ -525,14 +510,6 @@ export function showClearDialog() {
 
 export function hideClearDialog() {
     return hideClearDialogAction();
-}
-
-export function showDiscardDialog() {
-    return showDiscardDialogAction();
-}
-
-export function hideDiscardDialog() {
-    return hideDiscardDialogAction();
 }
 
 export function saveServerSetup(filename) {

--- a/lib/containers/ServerSetup.jsx
+++ b/lib/containers/ServerSetup.jsx
@@ -85,8 +85,6 @@ class ServerSetup extends React.PureComponent {
         this.saveChangedAttribute = this.saveChangedAttribute.bind(this);
         this.onModified = this.onModified.bind(this);
         this.onSelectComponent = this.onSelectComponent.bind(this);
-        this.onDiscardCancel = this.onDiscardCancel.bind(this);
-        this.onDiscardOk = this.onDiscardOk.bind(this);
         this.onClickApply = this.onClickApply.bind(this);
     }
 
@@ -125,27 +123,13 @@ class ServerSetup extends React.PureComponent {
     }
 
     onSelectComponent(instanceId) {
-        const { selectComponent, showDiscardDialog } = this.props;
+        const { selectComponent } = this.props;
         if (!this.modified) {
             selectComponent(instanceId);
             return;
         }
 
         this.pendingSelectInstanceId = instanceId;
-        showDiscardDialog();
-    }
-
-    onDiscardCancel() {
-        const { hideDiscardDialog } = this.props;
-        this.pendingSelectInstanceId = null;
-
-        hideDiscardDialog();
-    }
-
-    onDiscardOk() {
-        const { hideDiscardDialog, selectComponent } = this.props;
-        hideDiscardDialog();
-        selectComponent(this.pendingSelectInstanceId);
     }
 
     onClickApply() {
@@ -271,7 +255,6 @@ class ServerSetup extends React.PureComponent {
         const {
             selectedAdapter,
             serverSetup,
-            // selectComponent,
             toggleAdvertising,
             setAttributeExpanded,
             addNewService,
@@ -286,8 +269,6 @@ class ServerSetup extends React.PureComponent {
             showClearDialog,
             hideClearDialog,
             showErrorDialog,
-            // showDiscardDialog,
-            // hideDiscardDialog,
         } = this.props;
 
         if (!serverSetup) {
@@ -298,7 +279,6 @@ class ServerSetup extends React.PureComponent {
             showingApplyDialog,
             showingDeleteDialog,
             showingClearDialog,
-            showingDiscardDialog,
             children,
         } = serverSetup;
 
@@ -471,14 +451,6 @@ class ServerSetup extends React.PureComponent {
                         okButtonText="Yes"
                         cancelButtonText="No"
                     />
-                    <ConfirmationDialog
-                        show={showingDiscardDialog}
-                        onOk={this.onDiscardOk}
-                        onCancel={this.onDiscardCancel}
-                        text="The attribute has been modified. Discard the changes?"
-                        okButtonText="Yes"
-                        cancelButtonText="No"
-                    />
                 </div>
             </div>
         );
@@ -524,8 +496,6 @@ ServerSetup.propTypes = {
     selectComponent: PropTypes.func.isRequired,
     setAttributeExpanded: PropTypes.func.isRequired,
     saveChangedAttribute: PropTypes.func.isRequired,
-    showDiscardDialog: PropTypes.func.isRequired,
-    hideDiscardDialog: PropTypes.func.isRequired,
     addNewService: PropTypes.func.isRequired,
     addNewCharacteristic: PropTypes.func.isRequired,
     addNewDescriptor: PropTypes.func.isRequired,

--- a/lib/reducers/serverSetupReducer.js
+++ b/lib/reducers/serverSetupReducer.js
@@ -55,7 +55,6 @@ const InitialState = Record({
     showingDeleteDialog: false,
     showingApplyDialog: false,
     showingClearDialog: false,
-    showingDiscardDialog: false,
     children: null,
 });
 
@@ -393,10 +392,6 @@ export default function serverSetup(state = initialState, action) {
             return state.set('showingClearDialog', true);
         case ServerSetupActions.HIDE_CLEAR_DIALOG:
             return state.set('showingClearDialog', false);
-        case ServerSetupActions.SHOW_DISCARD_DIALOG:
-            return state.set('showingDiscardDialog', true);
-        case ServerSetupActions.HIDE_DISCARD_DIALOG:
-            return state.set('showingDiscardDialog', false);
         case ServerSetupActions.LOAD:
             return loadSetup(state, action.setup);
         case AdapterAction.ADAPTER_CLOSED:


### PR DESCRIPTION
When modifying server setup, if the user makes a change to a service, characteristic or descriptor, but then clicks on another of these components before clicking save, they will be presented with a discard dialog.
![image](https://user-images.githubusercontent.com/72191781/100359400-c3014500-2ff7-11eb-8626-f3f408908dde.png)

However this dialog currently does not do anything, and the changes are discarded regardless of the user clicking Yes or No. So for now we can just remove this dialog until we decide that we want to fix this behavior properly.