### PR TITLE
Improve UX for delete bond information

### DIFF
--- a/lib/components/CentralDevice.jsx
+++ b/lib/components/CentralDevice.jsx
@@ -177,6 +177,12 @@ const CentralDevice = ({
                         key="deleteBondInfo"
                         title="Delete bond information"
                         onSelect={onDeleteBondInfo}
+                        disabled={
+                            security === null
+                                ? true
+                                : security.bondStore.size === 0
+                        }
+                        // burde den huske hva som er bounded når man restarter app
                     >
                         Delete bond information
                     </Dropdown.Item>

--- a/lib/components/CentralDevice.jsx
+++ b/lib/components/CentralDevice.jsx
@@ -178,9 +178,7 @@ const CentralDevice = ({
                         title="Delete bond information"
                         onSelect={onDeleteBondInfo}
                         disabled={
-                            security === null
-                                ? true
-                                : security.bondStore.size === 0
+                            security === null || security.bondStore.size === 0
                         }
                     >
                         Delete bond information

--- a/lib/components/CentralDevice.jsx
+++ b/lib/components/CentralDevice.jsx
@@ -182,7 +182,6 @@ const CentralDevice = ({
                                 ? true
                                 : security.bondStore.size === 0
                         }
-                        // burde den huske hva som er bounded når man restarter app
                     >
                         Delete bond information
                     </Dropdown.Item>


### PR DESCRIPTION
Task NCP-3421
This will indicate to user if there are stored any bond keys. 
The "Delete bond information" in the menu is disabled if we have no bounds