### PR TITLE
Feature/presist adv+scan params

### DIFF
--- a/lib/common/Persistentstore.js
+++ b/lib/common/Persistentstore.js
@@ -50,11 +50,7 @@ const ADV_PARAMS = 'AdvParams';
 function writeToStore(key) {
     return function setParams(params) {
         if (params !== undefined && params !== null) {
-            // This part is slow somethimes. why?
-            const startTime = performance.now();
             store.set(key, params);
-            const duration = performance.now() - startTime;
-            console.log(`putting in store took ${duration}ms`);
         }
     };
 }

--- a/lib/common/Persistentstore.js
+++ b/lib/common/Persistentstore.js
@@ -50,7 +50,12 @@ const ADV_PARAMS = 'AdvParams';
 function writeToStore(key) {
     return function setParams(params) {
         if (params !== undefined && params !== null) {
+            // This part is slow. Must change? why? store to big? too much data?
+            // ... handler took ... ms
+            const startTime = performance.now();
             store.set(key, params);
+            const duration = performance.now() - startTime;
+            console.log(`putting in store took ${duration}ms`);
         }
     };
 }

--- a/lib/common/Persistentstore.js
+++ b/lib/common/Persistentstore.js
@@ -50,8 +50,7 @@ const ADV_PARAMS = 'AdvParams';
 function writeToStore(key) {
     return function setParams(params) {
         if (params !== undefined && params !== null) {
-            // This part is slow. Must change? why? store to big? too much data?
-            // ... handler took ... ms
+            // This part is slow somethimes. why?
             const startTime = performance.now();
             store.set(key, params);
             const duration = performance.now() - startTime;

--- a/lib/common/Persistentstore.js
+++ b/lib/common/Persistentstore.js
@@ -45,7 +45,7 @@ const AUTO_UPDATE_KEY = 'AutoUpdate';
 const SECURITY_KEY = 'Security';
 const ACTIVE_SCAN = 'ActiveScan';
 const SCAN_TIMEOUT = 'ScanTimeout';
-const ADV_PARAMS = 'AdvParams'
+const ADV_PARAMS = 'AdvParams';
 
 function writeToStore(key) {
     return function setParams(params) {
@@ -74,5 +74,5 @@ export const persistentStore = {
     autoConnUpdate: () => store.get(AUTO_UPDATE_KEY, true),
     activeScan: () => store.get(ACTIVE_SCAN, true),
     scanTimeout: () => store.get(SCAN_TIMEOUT, 60),
-    advParams: () => store.get(ADV_PARAMS, {interval: 100, timeout: 0})
+    advParams: () => store.get(ADV_PARAMS, { interval: 100, timeout: 0 }),
 };

--- a/lib/common/Persistentstore.js
+++ b/lib/common/Persistentstore.js
@@ -43,6 +43,9 @@ const SCAN_KEY = 'Scan';
 const AUTO_ACCEPT_KEY = 'AutoAccept';
 const AUTO_UPDATE_KEY = 'AutoUpdate';
 const SECURITY_KEY = 'Security';
+const ACTIVE_SCAN = 'ActiveScan';
+const SCAN_TIMEOUT = 'ScanTimeout';
+const ADV_PARAMS = 'AdvParams'
 
 function writeToStore(key) {
     return function setParams(params) {
@@ -58,6 +61,9 @@ export const persistentStore = {
     setSecParams: writeToStore(SECURITY_KEY),
     setAutoAcceptPairing: writeToStore(AUTO_ACCEPT_KEY),
     setAutoConnUpdate: writeToStore(AUTO_UPDATE_KEY),
+    setActiveScan: writeToStore(ACTIVE_SCAN),
+    setScanTimeout: writeToStore(SCAN_TIMEOUT),
+    setAdvParams: writeToStore(ADV_PARAMS),
     secParams: defaultParams => ({
         ...defaultParams,
         ...store.get(SECURITY_KEY),
@@ -66,4 +72,7 @@ export const persistentStore = {
     scanResponse: () => store.get(SCAN_KEY, []),
     autoAcceptPairing: () => store.get(AUTO_ACCEPT_KEY, true),
     autoConnUpdate: () => store.get(AUTO_UPDATE_KEY, true),
+    activeScan: () => store.get(ACTIVE_SCAN, true),
+    scanTimeout: () => store.get(SCAN_TIMEOUT, 60),
+    advParams: () => store.get(ADV_PARAMS, {interval: 100, timeout: 0})
 };

--- a/lib/containers/AdvertisingParams.jsx
+++ b/lib/containers/AdvertisingParams.jsx
@@ -61,7 +61,12 @@ class AdvertisingParams extends React.PureComponent {
         const { setAdvParams, hideAdvParamDialog } = this.props;
         const { advParams } = this.state;
 
-        if (!advParams || !advParams.interval || !advParams.timeout) return;
+        if (
+            !advParams ||
+            !advParams.interval ||
+            (!advParams.timeout && advParams.timeout !== 0)
+        )
+            return;
 
         setAdvParams(advParams);
         hideAdvParamDialog();

--- a/lib/containers/DiscoveredDevices.jsx
+++ b/lib/containers/DiscoveredDevices.jsx
@@ -299,7 +299,7 @@ DiscoveredDevices.propTypes = {
     toggleExpanded: PropTypes.func.isRequired,
     changeActiveScan: PropTypes.func.isRequired,
     setTimeoutChange: PropTypes.func.isRequired,
-    discoveryOptions: PropTypes.instanceOf(DiscoveryOptions),
+    discoveryOptions: PropTypes.objectOf(DiscoveryOptions),
 };
 
 DiscoveredDevices.defaultProps = {

--- a/lib/reducers/advertisingReducer.js
+++ b/lib/reducers/advertisingReducer.js
@@ -128,7 +128,7 @@ export default function advertising(state = initialState, action) {
         case advertisingActions.SHOW_ADV_PARAMS:
             return state.set('showAdvParams', true);
         case advertisingActions.SET_ADVERTISING_PARAMS:
-            persistentStore.setAdvParams(action.params); 
+            persistentStore.setAdvParams(action.params);
             // click handler took ... ms. kan være vi må gøre om fra number til text?
             return state.set('advParams', action.params);
         default:

--- a/lib/reducers/advertisingReducer.js
+++ b/lib/reducers/advertisingReducer.js
@@ -54,24 +54,27 @@ const defaultAdvData = [
     },
 ];
 
+
+// er bare lagret i starten så gir feil ved kobling til ny device
+// bruke new record?
 const storedAdvEntries = persistentStore.advSetup();
 const storedScanResponseEntries = persistentStore.scanResponse();
 const advDataEntries =
     storedAdvEntries.length === 0 ? defaultAdvData : storedAdvEntries;
-const InitialState = Record({
-    advDataEntries: List(advDataEntries),
-    scanResponseEntries: List(storedScanResponseEntries),
-    tempAdvDataEntries: List(advDataEntries),
-    tempScanRespEntries: List(storedScanResponseEntries),
-    show: false,
-    setAdvdataStatus: '',
-    showAdvParams: false,
-    advParams: persistentStore.advParams(),
-});
 
-const initialState = new InitialState();
+const getInitialState = () =>
+    new Record({
+        advDataEntries: List(advDataEntries),
+        scanResponseEntries: List(storedScanResponseEntries),
+        tempAdvDataEntries: List(advDataEntries),
+        tempScanRespEntries: List(storedScanResponseEntries),
+        show: false,
+        setAdvdataStatus: '',
+        showAdvParams: false,
+        advParams: persistentStore.advParams(),
+    })();
 
-export default function advertising(state = initialState, action) {
+export default function advertising(state = getInitialState(), action) {
     switch (action.type) {
         case advertisingActions.ADD_ADVDATA_ENTRY:
             return state.set(
@@ -120,7 +123,7 @@ export default function advertising(state = initialState, action) {
             logger.info('Advertising stopped');
             return state;
         case AdapterAction.ADAPTER_RESET_PERFORMED:
-            return initialState;
+            return getInitialState();
         case advertisingActions.LOAD:
             return state
                 .set('tempAdvDataEntries', List(action.advSetup))
@@ -129,7 +132,6 @@ export default function advertising(state = initialState, action) {
             return state.set('showAdvParams', true);
         case advertisingActions.SET_ADVERTISING_PARAMS:
             persistentStore.setAdvParams(action.params);
-            // click handler took ... ms. kan være vi må gøre om fra number til text?
             return state.set('advParams', action.params);
         default:
             return state;

--- a/lib/reducers/advertisingReducer.js
+++ b/lib/reducers/advertisingReducer.js
@@ -54,19 +54,21 @@ const defaultAdvData = [
     },
 ];
 
-// er bare lagret i starten så gir feil ved kobling til ny device
-// bruke new record?
-const storedAdvEntries = persistentStore.advSetup();
-const storedScanResponseEntries = persistentStore.scanResponse();
-const advDataEntries =
-    storedAdvEntries.length === 0 ? defaultAdvData : storedAdvEntries;
+const storedScanResponseEntries = () => {
+    return persistentStore.scanResponse();
+};
+const advDataEntries = () => {
+    const storedAdvEntries = persistentStore.advSetup();
+    console.log(storedAdvEntries);
+    return storedAdvEntries.length === 0 ? defaultAdvData : storedAdvEntries;
+};
 
 const getInitialState = () =>
     new Record({
-        advDataEntries: List(advDataEntries),
-        scanResponseEntries: List(storedScanResponseEntries),
-        tempAdvDataEntries: List(advDataEntries),
-        tempScanRespEntries: List(storedScanResponseEntries),
+        advDataEntries: List(advDataEntries()),
+        scanResponseEntries: List(storedScanResponseEntries()),
+        tempAdvDataEntries: List(advDataEntries()),
+        tempScanRespEntries: List(storedScanResponseEntries()),
         show: false,
         setAdvdataStatus: '',
         showAdvParams: false,

--- a/lib/reducers/advertisingReducer.js
+++ b/lib/reducers/advertisingReducer.js
@@ -66,10 +66,7 @@ const InitialState = Record({
     show: false,
     setAdvdataStatus: '',
     showAdvParams: false,
-    advParams: {
-        interval: 100,
-        timeout: 0,
-    },
+    advParams: persistentStore.advParams(),
 });
 
 const initialState = new InitialState();
@@ -131,6 +128,8 @@ export default function advertising(state = initialState, action) {
         case advertisingActions.SHOW_ADV_PARAMS:
             return state.set('showAdvParams', true);
         case advertisingActions.SET_ADVERTISING_PARAMS:
+            persistentStore.setAdvParams(action.params); 
+            // click handler took ... ms. kan være vi må gøre om fra number til text?
             return state.set('advParams', action.params);
         default:
             return state;

--- a/lib/reducers/advertisingReducer.js
+++ b/lib/reducers/advertisingReducer.js
@@ -59,7 +59,6 @@ const storedScanResponseEntries = () => {
 };
 const advDataEntries = () => {
     const storedAdvEntries = persistentStore.advSetup();
-    console.log(storedAdvEntries);
     return storedAdvEntries.length === 0 ? defaultAdvData : storedAdvEntries;
 };
 

--- a/lib/reducers/advertisingReducer.js
+++ b/lib/reducers/advertisingReducer.js
@@ -54,7 +54,6 @@ const defaultAdvData = [
     },
 ];
 
-
 // er bare lagret i starten så gir feil ved kobling til ny device
 // bruke new record?
 const storedAdvEntries = persistentStore.advSetup();

--- a/lib/reducers/discoveryReducer.js
+++ b/lib/reducers/discoveryReducer.js
@@ -186,9 +186,9 @@ function discoverySetOptions(state, options) {
 }
 
 function setTimeout(state, value) {
-    //handler took ... ms violation hvorfor?
+    // handler took ... ms violation hvorfor?
     persistentStore.setScanTimeout(+value);
-    return state.setIn(['options', 'scanTimeout'], +a);
+    return state.setIn(['options', 'scanTimeout'], +value);
 }
 
 function toggleActiveScan(state) {

--- a/lib/reducers/discoveryReducer.js
+++ b/lib/reducers/discoveryReducer.js
@@ -39,6 +39,7 @@
 import { Record, OrderedMap, List } from 'immutable';
 import { logger } from 'nrfconnect/core';
 
+import { persistentStore } from '../common/Persistentstore';
 import * as DiscoveryAction from '../actions/discoveryActions';
 import * as AdapterAction from '../actions/adapterActions';
 import * as apiHelper from '../utils/api';
@@ -49,8 +50,8 @@ export const DiscoveryOptions = Record({
     filterString: '',
     scanInterval: 100,
     scanWindow: 20,
-    scanTimeout: 60,
-    activeScan: true,
+    scanTimeout: persistentStore.scanTimeout(), // kan ikke ligge i den exported?
+    activeScan: persistentStore.activeScan(), // den husekr hva den var helt i starten
     filterRegexp: '',
 });
 
@@ -185,10 +186,13 @@ function discoverySetOptions(state, options) {
 }
 
 function setTimeout(state, value) {
-    return state.setIn(['options', 'scanTimeout'], +value);
+    //handler took ... ms violation hvorfor?
+    persistentStore.setScanTimeout(+value);
+    return state.setIn(['options', 'scanTimeout'], +a);
 }
 
-function setActiveScan(state) {
+function toggleActiveScan(state) {
+    persistentStore.setActiveScan(!state.options.activeScan); // fungerer på refresh, men ikke koble til ny device
     return state.updateIn(['options', 'activeScan'], value => !value);
 }
 
@@ -211,7 +215,7 @@ export default function discovery(state = initialState, action) {
         case DiscoveryAction.DISCOVERY_SET_TIMEOUT:
             return setTimeout(state, action.value);
         case DiscoveryAction.DISCOVERY_ACTIVE_SCAN:
-            return setActiveScan(state);
+            return toggleActiveScan(state);
         case AdapterAction.DEVICE_DISCOVERED:
             return deviceDiscovered(state, action.device);
         case AdapterAction.DEVICE_CONNECT:

--- a/lib/reducers/discoveryReducer.js
+++ b/lib/reducers/discoveryReducer.js
@@ -46,13 +46,14 @@ import * as apiHelper from '../utils/api';
 
 export const DiscoveryOptions = params =>
     new Record({
+        // bare record?
         expanded: false,
         sortByRssi: false,
         filterString: '',
         scanInterval: 100,
         scanWindow: 20,
-        scanTimeout: persistentStore.scanTimeout(),
-        activeScan: persistentStore.activeScan(),
+        scanTimeout: persistentStore.scanTimeout(), // gjøre disse til new recod ?
+        activeScan: persistentStore.activeScan(), // må fikse feilmelding
         filterRegexp: '',
     })(params);
 
@@ -182,7 +183,7 @@ function discoverySetOptions(state, options) {
         ...options,
         filterRegexp: new RegExp(options.filterString, 'i'),
     };
-    return applyFilters(state.set('options', DiscoveryOptions(newOptions))); // hmmm?
+    return applyFilters(state.set('options', DiscoveryOptions(newOptions))); // isåfall endres tilbake
 }
 
 function setTimeout(state, value) {

--- a/lib/reducers/discoveryReducer.js
+++ b/lib/reducers/discoveryReducer.js
@@ -46,14 +46,13 @@ import * as apiHelper from '../utils/api';
 
 export const DiscoveryOptions = params =>
     new Record({
-        // bare record?
         expanded: false,
         sortByRssi: false,
         filterString: '',
         scanInterval: 100,
         scanWindow: 20,
-        scanTimeout: persistentStore.scanTimeout(), // gjøre disse til new recod ?
-        activeScan: persistentStore.activeScan(), // må fikse feilmelding
+        scanTimeout: persistentStore.scanTimeout(),
+        activeScan: persistentStore.activeScan(),
         filterRegexp: '',
     })(params);
 
@@ -183,7 +182,7 @@ function discoverySetOptions(state, options) {
         ...options,
         filterRegexp: new RegExp(options.filterString, 'i'),
     };
-    return applyFilters(state.set('options', DiscoveryOptions(newOptions))); // isåfall endres tilbake
+    return applyFilters(state.set('options', DiscoveryOptions(newOptions)));
 }
 
 function setTimeout(state, value) {

--- a/lib/reducers/discoveryReducer.js
+++ b/lib/reducers/discoveryReducer.js
@@ -60,7 +60,7 @@ const getInitialState = () =>
     new Record({
         devices: OrderedMap(),
         errors: List(),
-        options: DiscoveryOptions(), 
+        options: DiscoveryOptions(),
     })();
 
 function scanStarted(state) {

--- a/lib/reducers/discoveryReducer.js
+++ b/lib/reducers/discoveryReducer.js
@@ -44,24 +44,24 @@ import * as DiscoveryAction from '../actions/discoveryActions';
 import * as AdapterAction from '../actions/adapterActions';
 import * as apiHelper from '../utils/api';
 
-export const DiscoveryOptions = Record({
-    expanded: false,
-    sortByRssi: false,
-    filterString: '',
-    scanInterval: 100,
-    scanWindow: 20,
-    scanTimeout: persistentStore.scanTimeout(), // kan ikke ligge i den exported?
-    activeScan: persistentStore.activeScan(), // den husekr hva den var helt i starten
-    filterRegexp: '',
-});
+export const DiscoveryOptions = params =>
+    new Record({
+        expanded: false,
+        sortByRssi: false,
+        filterString: '',
+        scanInterval: 100,
+        scanWindow: 20,
+        scanTimeout: persistentStore.scanTimeout(),
+        activeScan: persistentStore.activeScan(),
+        filterRegexp: '',
+    })(params);
 
-const InitialState = Record({
-    devices: OrderedMap(),
-    errors: List(),
-    options: new DiscoveryOptions(),
-});
-
-const initialState = new InitialState();
+const getInitialState = () =>
+    new Record({
+        devices: OrderedMap(),
+        errors: List(),
+        options: DiscoveryOptions(), 
+    })();
 
 function scanStarted(state) {
     logger.info('Scan started');
@@ -182,21 +182,20 @@ function discoverySetOptions(state, options) {
         ...options,
         filterRegexp: new RegExp(options.filterString, 'i'),
     };
-    return applyFilters(state.set('options', new DiscoveryOptions(newOptions)));
+    return applyFilters(state.set('options', DiscoveryOptions(newOptions))); // hmmm?
 }
 
 function setTimeout(state, value) {
-    // handler took ... ms violation hvorfor?
     persistentStore.setScanTimeout(+value);
     return state.setIn(['options', 'scanTimeout'], +value);
 }
 
 function toggleActiveScan(state) {
-    persistentStore.setActiveScan(!state.options.activeScan); // fungerer på refresh, men ikke koble til ny device
+    persistentStore.setActiveScan(!state.options.activeScan);
     return state.updateIn(['options', 'activeScan'], value => !value);
 }
 
-export default function discovery(state = initialState, action) {
+export default function discovery(state = getInitialState(), action) {
     switch (action.type) {
         case DiscoveryAction.DISCOVERY_CLEAR_LIST:
             return clearList(state);
@@ -229,9 +228,9 @@ export default function discovery(state = initialState, action) {
         case AdapterAction.DEVICE_CANCEL_CONNECT:
             return deviceCancelConnect(state);
         case AdapterAction.ADAPTER_RESET_PERFORMED:
-            return initialState;
+            return getInitialState();
         case AdapterAction.ADAPTER_CLOSED:
-            return initialState;
+            return getInitialState();
         default:
             return state;
     }

--- a/resources/css/styles.scss
+++ b/resources/css/styles.scss
@@ -714,7 +714,7 @@
 
 .adv-value {
     display: inline-block;
-    margin-left: 16px;
+    margin-left: 17px;
     @include text-smaller;
 }
 


### PR DESCRIPTION
This pull request will persist user settings in "Discovered device" and "Advertising parameters". (https://projecttools.nordicsemi.no/jira/browse/NCP-3466)
Will also fix bug where advertising setup was not remembered when changing or reloading device without reloading app first.