### PR TITLE
Revert moving electron store dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "change-case": "^4.1.0",
     "chart.js": "^2.9.3",
-    "electron-store": "^6.0.0",
     "immutable": "^3.8.2",
     "jquery": "^3.4.1",
     "lodash.throttle": "^4.1.1",
@@ -48,7 +47,8 @@
     "react-redux": "7.2.0"
   },
   "dependencies": {
-    "bluetooth-uuid-database": "github:NordicSemiconductor/bluetooth-numbers-database#75bb6a8079"    
+    "bluetooth-uuid-database": "github:NordicSemiconductor/bluetooth-numbers-database#75bb6a8079",
+    "electron-store": "^6.0.0"
   },
   "bundledDependencies": [
     "bluetooth-uuid-database",


### PR DESCRIPTION
We moved the dependency to facilitate for the build pipeline, but this breaks the app, so revert changes.