### PR TITLE
Add missing parsing of TEXT format for descriptors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 2.5.3 - 2021-08-24
+### Fixed
+- TEXT format definitions were not applied for descriptors.
+
 ## 2.5.2 - 2021-08-02
 ### Fixed
 - The image on the DFU button was not displayed anymore.

--- a/lib/components/DescriptorItem.jsx
+++ b/lib/components/DescriptorItem.jsx
@@ -39,6 +39,7 @@
 import React from 'react';
 import { is as ImmutableIs, Map } from 'immutable';
 
+import { getUuidFormat, TEXT } from '../utils/uuid_definitions';
 import { getInstanceIds } from '../utils/api';
 import AttributeItem, { CCCD_UUID } from './AttributeItem';
 import HexOnlyEditableField from './HexOnlyEditableField';
@@ -85,6 +86,8 @@ class DescriptorItem extends AttributeItem {
 
         const valueList = [];
 
+        const showText = getUuidFormat(uuid) === TEXT;
+
         if (isLocalCCCD && Map.isMap(value)) {
             value.forEach((cccdValue, deviceInstanceId) => {
                 const { address } = getInstanceIds(deviceInstanceId);
@@ -98,6 +101,7 @@ class DescriptorItem extends AttributeItem {
                         onRead={onRead}
                         showReadButton={itemIsSelected}
                         selectParent={this.selectComponent}
+
                     />
                 );
             });
@@ -110,6 +114,7 @@ class DescriptorItem extends AttributeItem {
                     onRead={onRead}
                     showReadButton={itemIsSelected}
                     selectParent={this.selectComponent}
+                    showText={showText}
                 />
             );
         }

--- a/lib/components/DescriptorItem.jsx
+++ b/lib/components/DescriptorItem.jsx
@@ -39,8 +39,8 @@
 import React from 'react';
 import { is as ImmutableIs, Map } from 'immutable';
 
-import { getUuidFormat, TEXT } from '../utils/uuid_definitions';
 import { getInstanceIds } from '../utils/api';
+import { getUuidFormat, TEXT } from '../utils/uuid_definitions';
 import AttributeItem, { CCCD_UUID } from './AttributeItem';
 import HexOnlyEditableField from './HexOnlyEditableField';
 
@@ -101,7 +101,6 @@ class DescriptorItem extends AttributeItem {
                         onRead={onRead}
                         showReadButton={itemIsSelected}
                         selectParent={this.selectComponent}
-
                     />
                 );
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-ble",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "A natural first choice for Bluetooth Low Energy development",
   "displayName": "Bluetooth Low Energy",
   "repository": {


### PR DESCRIPTION
TEXT format was being parsed correctly for characteristics, but not for descriptors.

(Contrieved) example after fix:
![image](https://user-images.githubusercontent.com/12543955/130455369-69b990b1-7e84-47fd-86f1-15e2f5fc85a3.png)

NCP-3758