### PR TITLE
Fix invisible buttons

### DIFF
--- a/lib/components/ActionButton.jsx
+++ b/lib/components/ActionButton.jsx
@@ -45,7 +45,7 @@ const ActionButton = ({ label, onClick, primary, className, ...rest }) => (
         type="button"
         onClick={onClick}
         className={`${className} btn btn-default btn-sm btn-nordic`}
-        variant={primary ? 'primary' : 'outline-secondary'}
+        variant={primary ? 'primary' : 'secondary'}
         {...rest}
     >
         {label}

--- a/lib/components/AdvertisingData.jsx
+++ b/lib/components/AdvertisingData.jsx
@@ -363,7 +363,7 @@ class AdvertisingData extends React.PureComponent {
                         id="dropdown-adv"
                         label="Type"
                         onSelect={this.handleSelect}
-                        variant="outline-secondary"
+                        variant="secondary"
                     >
                         <Dropdown.Item eventKey="0">
                             {keyToAdvertisingType('0')}

--- a/lib/components/AdvertisingListEntry.jsx
+++ b/lib/components/AdvertisingListEntry.jsx
@@ -64,7 +64,7 @@ class AdvertisingListEntry extends React.PureComponent {
                         className="mdi mdi-close-circle adv-data-delete"
                         size="sm"
                         onClick={this.onButtonClicked}
-                        variant="outline-secondary"
+                        variant="secondary"
                     >
                         {' Delete'}
                     </Button>

--- a/lib/components/DfuEditor.jsx
+++ b/lib/components/DfuEditor.jsx
@@ -132,7 +132,7 @@ class DfuEditor extends React.PureComponent {
                         <InputGroup.Append>
                             <Button
                                 id="choose-file"
-                                variant="outline-secondary"
+                                variant="secondary"
                                 disabled={isStarted || isCompleted}
                                 onClick={onChooseFile}
                             >

--- a/lib/components/PairingEditor.jsx
+++ b/lib/components/PairingEditor.jsx
@@ -104,7 +104,7 @@ class PairingEditor extends React.PureComponent {
                     type="button"
                     onClick={this.handleCancel}
                     className="btn btn-default btn-sm btn-nordic"
-                    variant="outline-secondary"
+                    variant="secondary"
                 >
                     Cancel
                 </Button>
@@ -144,7 +144,7 @@ class PairingEditor extends React.PureComponent {
                     type="button"
                     onClick={this.handleReject}
                     className="btn btn-default btn-sm btn-nordic"
-                    variant="outline-secondary"
+                    variant="secondary"
                 >
                     Reject
                 </Button>
@@ -158,7 +158,7 @@ class PairingEditor extends React.PureComponent {
                     type="button"
                     onClick={this.handleCancel}
                     className="btn btn-default btn-sm btn-nordic"
-                    variant="outline-secondary"
+                    variant="secondary"
                 >
                     Ignore
                 </Button>

--- a/lib/components/SecurityParamsControls.jsx
+++ b/lib/components/SecurityParamsControls.jsx
@@ -124,7 +124,7 @@ class SecurityParamsControls extends React.PureComponent {
                             onSelect={(eventKey, event) =>
                                 this.onIoCapsSelect(event, eventKey)
                             }
-                            variant="outline-secondary"
+                            variant="secondary"
                         >
                             <Dropdown.Item eventKey={IO_CAPS_DISPLAY_ONLY}>
                                 {keyToIoCapsText(IO_CAPS_DISPLAY_ONLY)}

--- a/lib/components/UuidLookup.jsx
+++ b/lib/components/UuidLookup.jsx
@@ -80,7 +80,7 @@ class UuidLookup extends React.Component {
                     onSelect={(eventKey, event) => onSelect(event, eventKey)}
                     alignRight={pullRight}
                 >
-                    <Dropdown.Toggle variant="outline-secondary" size="lg">
+                    <Dropdown.Toggle variant="secondary" size="lg">
                         <span className="mdi mdi-magnify" aria-hidden="true" />
                     </Dropdown.Toggle>
                     <Dropdown.Menu className="scroll-menu">

--- a/lib/components/__tests__/__snapshots__/DfuEditor-snapshot-test.jsx.snap
+++ b/lib/components/__tests__/__snapshots__/DfuEditor-snapshot-test.jsx.snap
@@ -24,7 +24,7 @@ exports[`DfuEditor should render stopping 1`] = `
         className="input-group-append"
       >
         <button
-          className="btn btn-outline-secondary"
+          className="btn btn-secondary"
           disabled={true}
           id="choose-file"
           onClick={[Function]}
@@ -133,7 +133,7 @@ exports[`DfuEditor should render with default props 1`] = `
         className="input-group-append"
       >
         <button
-          className="btn btn-outline-secondary"
+          className="btn btn-secondary"
           disabled={false}
           id="choose-file"
           onClick={[Function]}
@@ -195,7 +195,7 @@ exports[`DfuEditor should render with dfu completed 1`] = `
         className="input-group-append"
       >
         <button
-          className="btn btn-outline-secondary"
+          className="btn btn-secondary"
           disabled={true}
           id="choose-file"
           onClick={[Function]}
@@ -308,7 +308,7 @@ exports[`DfuEditor should render with file path 1`] = `
         className="input-group-append"
       >
         <button
-          className="btn btn-outline-secondary"
+          className="btn btn-secondary"
           disabled={false}
           id="choose-file"
           onClick={[Function]}
@@ -366,7 +366,7 @@ exports[`DfuEditor should render with file path and package info 1`] = `
         className="input-group-append"
       >
         <button
-          className="btn btn-outline-secondary"
+          className="btn btn-secondary"
           disabled={false}
           id="choose-file"
           onClick={[Function]}
@@ -443,7 +443,7 @@ exports[`DfuEditor should render with file path, package info, and dfu in progre
         className="input-group-append"
       >
         <button
-          className="btn btn-outline-secondary"
+          className="btn btn-secondary"
           disabled={true}
           id="choose-file"
           onClick={[Function]}

--- a/lib/containers/AdvertisingParams.jsx
+++ b/lib/containers/AdvertisingParams.jsx
@@ -109,7 +109,7 @@ class AdvertisingParams extends React.PureComponent {
                             type="button"
                             onClick={() => this.handleCancel()}
                             className="btn btn-default btn-sm btn-nordic"
-                            variant="outline-secondary"
+                            variant="secondary"
                         >
                             Cancel
                         </Button>

--- a/lib/containers/AdvertisingSetup.jsx
+++ b/lib/containers/AdvertisingSetup.jsx
@@ -212,16 +212,10 @@ class AdvertisingSetup extends React.PureComponent {
                 </Modal.Body>
                 <Modal.Footer className="advertising-setup-footer">
                     <div>
-                        <Button
-                            variant="outline-secondary"
-                            onClick={this.handleLoad}
-                        >
+                        <Button variant="secondary" onClick={this.handleLoad}>
                             Load setup
                         </Button>
-                        <Button
-                            variant="outline-secondary"
-                            onClick={this.handleSave}
-                        >
+                        <Button variant="secondary" onClick={this.handleSave}>
                             Save setup
                         </Button>
                     </div>
@@ -232,10 +226,7 @@ class AdvertisingSetup extends React.PureComponent {
                         >
                             Apply
                         </Button>
-                        <Button
-                            variant="outline-secondary"
-                            onClick={hideSetupDialog}
-                        >
+                        <Button variant="secondary" onClick={hideSetupDialog}>
                             Close
                         </Button>
                     </div>

--- a/lib/containers/ConnectionParams.jsx
+++ b/lib/containers/ConnectionParams.jsx
@@ -102,7 +102,7 @@ class ConnectionParams extends React.PureComponent {
                             type="button"
                             onClick={hideConnectionParamDialog}
                             className="btn btn-default btn-sm btn-nordic"
-                            variant="outline-secondary"
+                            variant="secondary"
                         >
                             Cancel
                         </Button>

--- a/lib/containers/SecurityParamsDialog.jsx
+++ b/lib/containers/SecurityParamsDialog.jsx
@@ -109,7 +109,7 @@ class SecurityParamsDialog extends React.PureComponent {
                             type="button"
                             onClick={() => this.handleCancel()}
                             className="btn btn-default btn-sm btn-nordic"
-                            variant="outline-secondary"
+                            variant="secondary"
                         >
                             Cancel
                         </Button>


### PR DESCRIPTION
Part of https://trello.com/c/j6lBuPvA/112-check-and-update-all-apps-with-new-architecture-and-apply-new-device-selector-in-all-apps.

On a white background “outline-secondary” buttons are invisible unless one hovers over them. So switch to normal “secondary” buttons.