### PR TITLE
Copy old persistent electron on initial standalone install

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,11 @@ import { lt } from 'semver';
 
 import { baseDownloadUrl, bleVersion, downloadSize } from './config';
 import { downloadInstaller, saveBufferToPath } from './downloadInstaller';
-import { getProgramPath, programDirectory } from './paths';
+import {
+    copyOldElectronStore,
+    getProgramPath,
+    programDirectory,
+} from './paths';
 import { currentVersion, runExecutable, runInstaller } from './run';
 
 import './style.css';
@@ -49,6 +53,7 @@ const Main = () => {
             const path = await saveBufferToPath(buffer);
             runInstaller(path);
             if (process.platform === 'darwin' || process.platform === 'linux') {
+                copyOldElectronStore();
                 getCurrentWindow().close();
             }
         } catch {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import { existsSync, readFileSync } from 'fs';
+import { copyFileSync, existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
 import { dirname, join, resolve } from 'path';
 
@@ -93,5 +93,26 @@ export function configDirectory(): string {
         case 'linux':
         default:
             return join(homedir(), '.config', packageName);
+    }
+}
+
+export function copyOldElectronStore(): void {
+    const pathToNewStorage = join(configDirectory(), 'pc-nrfconnect-ble.json');
+    console.log(`Checking if: ${pathToNewStorage} exists.`);
+    if (!existsSync(pathToNewStorage)) {
+        // If storage of Bluetooth Low Energy does not exist for the new userDataDir,
+        // check if there is an old storage of the app for when it was not a standalone app
+        // if there is an old storage, copy it to the new directory so as to migrate the storage
+        // to the standalone application. We do not want customers to loose their persistent store.
+        const pathToOldStorage = join(
+            configDirectory(),
+            '..',
+            'nrfconnect',
+            'pc-nrfconnect-ble.json'
+        );
+        console.log(`Checking if: ${pathToOldStorage} exists.`);
+        if (existsSync(pathToOldStorage)) {
+            copyFileSync(pathToOldStorage, pathToNewStorage);
+        }
     }
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -11,7 +11,7 @@ import { join } from 'path';
 import { usageData } from 'pc-nrfconnect-shared';
 
 import { bleVersion } from './config';
-import { configDirectory, getProgramPath } from './paths';
+import { configDirectory, copyOldElectronStore, getProgramPath } from './paths';
 
 export const runInstaller = (path: string) => {
     usageData.sendUsageData(
@@ -36,6 +36,7 @@ export const runInstaller = (path: string) => {
             installerProcess.on('close', code => {
                 if (code === 0) {
                     // Installation complete
+                    copyOldElectronStore();
                     getCurrentWindow().close();
                 }
             });


### PR DESCRIPTION
We want the customer to experience that they are able to use the standalone application just like they've done before. Therefore, the persistent store should automatically be migrated to the new location.

Notice that running `copyOldElectronStore()` will not pause the installer to launch the **Bluetooth Low Energy** Application, and I'm therefore unsure if this is a solid implementation of the migration.
The problem would occur if the application is able to create the `pc-nrfconnect-ble.json` before the function tests if it exists, and would then not copy the old json file, even though the new one is ~empty.


A possible solution would be to also check the content of the new `pc-nrfconnect-ble.json`, or just the content length. But if the current implementation is sufficient, it's probably ok left as is.


Tested locally on Windows and it worked fine.
