### PR TITLE
Synchronize version and JLink message

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,17 @@
+## 4.0.2 - 2022-11-03
+
+### Fixed
+
+-   The version displayed in nRF Connect for Desktop and in the Bluetooth Low
+    Energy Application was not synchronized.
+-   The log informed that the provided JLink version was v7.58b, it is now
+    updated to say v7.66a, similar to the other apps.
+
 ## 4.0.1 - 2022-10-10
 
 ### Fixed
 
--   Issue with appication not loading with error
+-   Issue with application not loading with error
     `nrfdl_create_context failed: 50`
 
 ## 4.0.0 - 2022-03-01

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-ble",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-ble",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "description": "A natural first choice for Bluetooth Low Energy development",
     "displayName": "Bluetooth Low Energy",
     "repository": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-export const bleVersion = '4.0.0';
+export const bleVersion = '4.0.2';
 export const packageName = 'nrfconnect-bluetooth-low-energy';
 export const baseDownloadUrl = `https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/bluetooth-standalone/v${bleVersion}/`;
 export const downloadSize = {


### PR DESCRIPTION
Version need to match with the standalone-ble application, and the JLink message (changed in the standalone application) need to match the rest of the apps.