### PR TITLE
Revert "Add v to v4.0.4"

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-export const bleVersion = 'v4.0.4';
+export const bleVersion = '4.0.4';
 export const packageName = 'nrfconnect-bluetooth-low-energy';
 export const baseDownloadUrl = `https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/bluetooth-standalone/v${bleVersion}/`;
 export const downloadSize = {


### PR DESCRIPTION
Reverts NordicSemiconductor/pc-nrfconnect-ble#267

It is not suppose to include `v`, because it uses the number in the filename inside
`downloadInstaller.ts`, which does not include `v`. As seen in `baseDownloadUrl`
the `v` is included in path.