### PR TITLE
Correct engine specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "license": "SEE LICENSE IN LICENSE",
     "main": "dist/bundle.js",
     "engines": {
-        "nrfconnect": "^3.11.0"
+        "nrfconnect": ">=3.11.0"
     },
     "scripts": {
         "watch": "run-p --silent --continue-on-error watch:*",


### PR DESCRIPTION
The caret was wrong because we expect the app to continue to work with also future major versions like `4.0.0`.