### PR TITLE
doc: update infocenter links

### DIFF
--- a/.github/workflows/zoomin-publish-dev.yml
+++ b/.github/workflows/zoomin-publish-dev.yml
@@ -1,4 +1,4 @@
-name: Publish documentation to Zoomin
+name: Publish documentation to Zoomin dev
 
 on:
   push:

--- a/.github/workflows/zoomin-publish.yml
+++ b/.github/workflows/zoomin-publish.yml
@@ -1,4 +1,4 @@
-name: Publish documentation to Zoomin
+name: Publish documentation to Zoomin prod
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ for reading and writing to the external nodes.
 
 ## Installation
 
-nRF Connect Bluetooth Low Energy is installed from nRF Connect from Desktop. For
+nRF Connect Bluetooth Low Energy is installed from nRF Connect for Desktop. For
 detailed steps, see
 [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
 in the nRF Connect from Desktop documentation.

--- a/doc/docs/dfu.md
+++ b/doc/docs/dfu.md
@@ -2,7 +2,7 @@
 
 If the connected device has Nordic Device Firmware Update (DFU) Service, you can update the firmware on the device.
 
-For more information on the DFU process, see [Device Firmware Update process](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v12.2.0/lib_bootloader_dfu_process.html). For DFU bootloader examples, see [DFU bootloader examples](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v12.2.0/examples_bootloader.html).
+For more information on the DFU process, see [Device Firmware Update process](https://docs.nordicsemi.com/bundle/sdk_nrf5_v17.1.0/page/lib_bootloader_dfu_process.html). For DFU bootloader examples, see [DFU bootloader examples](https://docs.nordicsemi.com/bundle/sdk_nrf5_v17.1.0/page/examples_bootloader.html).
 
 For a device that has DFU Service, Secure DFU appears in the device's list of discovered services, and the **Start Secure DFU** button appears in the list header.
 
@@ -14,7 +14,7 @@ To update the firmware, complete the following steps:
 2. Browse and select a DFU zip package file on your computer.
 
     !!! tip "Important"
-         To create the DFU zip package file, use the nrfutil tool. See the [nrfutil documentation](https://infocenter.nordicsemi.com/topic/ug_nrfutil/UG/nrfutil/nrfutil_intro.html) for more information.
+         To create the DFU zip package file, use the nRF Util tool. See the [nRF Util documentation](https://docs.nordicsemi.com/bundle/nrfutil/page/README.html) for more information.
     Information on the content of the DFU zip package is displayed in the **Package info** field.
 
     ![DFU dialog](./screenshots/nRF_connect_dfu_start.png "DFU dialog")

--- a/doc/docs/revision_history.md
+++ b/doc/docs/revision_history.md
@@ -7,7 +7,7 @@
 | September 2022 | Updated for installation changes in nRF Connect Bluetooth® Low Energy v4.0.0 and new user interface in version 3.0.1 and later |
 | June 2021 | Editorial changes |
 | September 2019   | Updated to match nRF Connect Bluetooth Low Energy v2.3.1:</br></br>- Updated [Installing the Bluetooth Low Energy app](installing.md)</br>- Clarified supported devices |
-| May 2019   | - Updated [Installing the Bluetooth Low Energy app](installing.md)</br> Editorial changes |
+| May 2019   | - Updated [Installing the Bluetooth Low Energy app](installing.md)</br>- Editorial changes |
 | June 2018   | Added support for nRF52840 Dongle PCA10059 |
 | February 2018   | Server setup can be applied multiple times with adapter reset |
 | July 2017   | - Application ported to new framework</br>- Added support for multiple custom properties in advertisement data</br>- Added support for Buttonless DFU Service |

--- a/doc/docs/revision_history.md
+++ b/doc/docs/revision_history.md
@@ -12,10 +12,3 @@
 | Jul 2017   | - Application ported to new framework</br>- Added support for multiple custom properties in advertisement data</br>- Added support for Buttonless DFU Service |
 | Jan 2017   | - Added Secure DFU</br>- Added support for nRF52 Development Kit PCA10056 |
 | Jul 2016   | First release |
-
-## Previous versions
-
-- [nRF Connect Bluetooth® Low Energy User Guide v2.3.1](https://infocenter.nordicsemi.com/pdf/nRFConnect_BLE_User_Guide_v2.3.1.pdf) (corresponds to nRF Connect Bluetooth Low Energy v2.3.1)
-- [nRF Connect Bluetooth® Low Energy User Guide v2.1](https://infocenter.nordicsemi.com/pdf/nRFConnect_BLE_User_Guide_v2.1.pdf) (corresponds to nRF Connect Bluetooth Low Energy v2.1.0)
-- [nRF Connect Getting Started Guide v1.1](https://infocenter.nordicsemi.com/pdf/nRF_Connect_v1.1.pdf) (corresponds to nRF Connect v1.1.0)
-- [nRF Connect Getting Started Guide v1.0](https://infocenter.nordicsemi.com/pdf/nRF_Connect_v1.0.pdf) (corresponds to nRF Connect v1.0.0)

--- a/doc/docs/revision_history.md
+++ b/doc/docs/revision_history.md
@@ -2,13 +2,14 @@
 
 | Date       | Description |
 |------------|-------------|
-| 2024-02-08 | Updated documentation for the [nRF Connect Bluetooth® Low Energy v4.0.4-patch1](https://github.com/NordicSemiconductor/pc-nrfconnect-ble/blob/main/Changelog.md#404-patch1---2023-09-05) together with several editorial changes to structure and layout. |
-| 2022-09-06 | Updated for installation changes in nRF Connect Bluetooth® Low Energy v4.0.0 and new user interface in version 3.0.1 and later. |
-| 2021-06-02 | Editorial changes |
-| Sep 2019   | Updated to match nRF Connect Bluetooth Low Energy v2.3.1:</br></br>- Updated [Installing the Bluetooth Low Energy app](installing.md)</br>- Clarified supported devices |
+| May 2024   | Editorial changes |
+| February 2024 | Updated documentation for the [nRF Connect Bluetooth® Low Energy v4.0.4-patch1](https://github.com/NordicSemiconductor/pc-nrfconnect-ble/blob/main/Changelog.md#404-patch1---2023-09-05) together with several editorial changes to structure and layout |
+| September 2022 | Updated for installation changes in nRF Connect Bluetooth® Low Energy v4.0.0 and new user interface in version 3.0.1 and later |
+| June 2021 | Editorial changes |
+| September 2019   | Updated to match nRF Connect Bluetooth Low Energy v2.3.1:</br></br>- Updated [Installing the Bluetooth Low Energy app](installing.md)</br>- Clarified supported devices |
 | May 2019   | - Updated [Installing the Bluetooth Low Energy app](installing.md)</br> Editorial changes |
-| Jun 2018   | Added support for nRF52840 Dongle PCA10059 |
-| Feb 2018   | Server setup can be applied multiple times with adapter reset |
-| Jul 2017   | - Application ported to new framework</br>- Added support for multiple custom properties in advertisement data</br>- Added support for Buttonless DFU Service |
-| Jan 2017   | - Added Secure DFU</br>- Added support for nRF52 Development Kit PCA10056 |
-| Jul 2016   | First release |
+| June 2018   | Added support for nRF52840 Dongle PCA10059 |
+| February 2018   | Server setup can be applied multiple times with adapter reset |
+| July 2017   | - Application ported to new framework</br>- Added support for multiple custom properties in advertisement data</br>- Added support for Buttonless DFU Service |
+| January 2017   | - Added Secure DFU</br>- Added support for nRF52 Development Kit PCA10056 |
+| July 2016   | First release |


### PR DESCRIPTION
Replaced Infocenter links with TechDocs.

----

Links to Infocenter that haven't been fixed (TBD): *links removed after checking with Ray*

----

Changelog not needed: doc file edits only.

- [x] Wait for deployment of nRF5 SDK to TechDocs and update bundle name in the links