### PR TITLE
chore: point workflows and package URLs to nordicsemi org

### DIFF
--- a/.github/workflows/docs-bundle.yml
+++ b/.github/workflows/docs-bundle.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
     create-doc-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-bundle.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-bundle.yml@main
         with:
             bundle-name: nrf-connect-ble

--- a/.github/workflows/docs-publish-dev.yml
+++ b/.github/workflows/docs-publish-dev.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
     publish-docs-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
         with:
             bundle-name: nrf-connect-ble
             release-type: dev

--- a/.github/workflows/docs-publish-prod.yml
+++ b/.github/workflows/docs-publish-prod.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     publish-docs-bundle:
-        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
+        uses: nordicsemi/pc-nrfconnect-shared/.github/workflows/docs-publish.yml@main
         with:
             bundle-name: nrf-connect-ble
             release-type: prod

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Bluetooth® Low Energy app
 
-[![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/pc-nrfconnect-ble?branchName=main)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=7&branchName=main)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
 The Bluetooth Low Energy app is a cross-platform tool that enables testing and

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ among other pages.
 
 ## Development
 
-See the
-[app development](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/)
+See the [app development](https://nordicsemi.github.io/pc-nrfconnect-docs/)
 pages for details on how to develop apps for the nRF Connect for Desktop
 framework.
 
@@ -47,7 +46,7 @@ Please report issues on the [DevZone](https://devzone.nordicsemi.com) portal.
 ## Contributing
 
 See the
-[information on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
+[information on contributing](https://nordicsemi.github.io/pc-nrfconnect-docs/contributing)
 for details.
 
 ## License

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -29,5 +29,5 @@ For installation instructions, see [Installing nRF Connect for Desktop apps](htt
 
 ## Application source code
 
-The code of the application is open source and [available on GitHub](https://github.com/NordicSemiconductor/pc-nrfconnect-ble).
+The code of the application is open source and [available on GitHub](https://github.com/nordicsemi/pc-nrfconnect-ble).
 Feel free to fork the repository and clone it for secondary development or feature contributions.

--- a/doc/docs/revision_history.yml
+++ b/doc/docs/revision_history.yml
@@ -23,7 +23,7 @@ sections:
   - "Editorial changes"
 - name: February 2024
   entries:
-  - "Updated documentation for the [Bluetooth Low Energy app v4.0.4-patch1](https://github.com/NordicSemiconductor/pc-nrfconnect-ble/blob/main/Changelog.md#404-patch1---2023-09-05) together with several editorial changes to structure and layout"
+  - "Updated documentation for the [Bluetooth Low Energy app v4.0.4-patch1](https://github.com/nordicsemi/pc-nrfconnect-ble/blob/main/Changelog.md#404-patch1---2023-09-05) together with several editorial changes to structure and layout"
 - name: September 2022
   entries:
   - "Updated for installation changes in the Bluetooth Low Energy app v4.0.0 and new user interface in version 3.0.1 and later"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "Changelog.md"
     ],
     "devDependencies": {
-        "@nordicsemiconductor/pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v98"
+        "@nordicsemiconductor/pc-nrfconnect-shared": "github:Nordicsemi/pc-nrfconnect-shared#v98"
     },
     "dependencies": {
         "bluetooth-numbers-database": "https://github.com/nordicsemi/bluetooth-numbers-database#75bb6a8079"

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
     "version": "4.0.4-patch1",
     "displayName": "Bluetooth Low Energy",
     "description": "General tool for development and testing with Bluetooth Low Energy",
-    "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-ble",
+    "homepage": "https://github.com/nordicsemi/pc-nrfconnect-ble",
     "repository": {
         "type": "git",
-        "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-ble.git"
+        "url": "https://github.com/nordicsemi/pc-nrfconnect-ble.git"
     },
     "author": "Nordic Semiconductor ASA",
     "license": "SEE LICENSE IN LICENSE",
@@ -43,7 +43,7 @@
         "@nordicsemiconductor/pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v98"
     },
     "dependencies": {
-        "bluetooth-numbers-database": "https://github.com/NordicSemiconductor/bluetooth-numbers-database#75bb6a8079"
+        "bluetooth-numbers-database": "https://github.com/nordicsemi/bluetooth-numbers-database#75bb6a8079"
     },
     "bundledDependencies": [
         "bluetooth-numbers-database",


### PR DESCRIPTION
Update reusable workflow references and repository homepage/URL from NordicSemiconductor to nordicsemi.

## Summary

Updates all reusable workflow `uses:` paths from `NordicSemiconductor/pc-nrfconnect-shared` to `nordicsemi/pc-nrfconnect-shared` to match the enterprise organization naming.

`package.json` `homepage` and `repository.url` point at the canonical **nordicsemi** org (not the former NordicSemiconductor naming).

## Notes

No functional workflow logic changes; only the repository path in composite/reusable workflow references, plus `package.json` metadata for the official GitHub location.